### PR TITLE
Cleanup and enhancements

### DIFF
--- a/biophysics/HHGate.cpp
+++ b/biophysics/HHGate.cpp
@@ -464,6 +464,7 @@ void HHGate::fillFromExpr(const Eref& e)
     double tau_;
     double inf_;
     symTab_.add_variable("v", v_);
+    symTab_.add_variable("c", v_);
     symTab_.add_variable("alpha", a_);
     symTab_.add_variable("beta", b_);
     symTab_.add_variable("tau", tau_);

--- a/msg/SparseMsg.h
+++ b/msg/SparseMsg.h
@@ -11,6 +11,7 @@
 #define _SPARSE_MSG_H
 
 #include "../randnum/randnum.h"
+#include "../basecode/SparseMatrix.h"
 
 /**
  * This is a parallelized sparse message.

--- a/pybind11/helper.cpp
+++ b/pybind11/helper.cpp
@@ -713,7 +713,7 @@ vector<ObjId> getNeighbors(const ObjId& obj, const string& fieldName,
                     fields.insert(tmp.begin(), tmp.end());
                 }
             }
-            if(fields.find(fieldName) != fields.end()) {
+            if(fieldName == "*" || fields.find(fieldName) != fields.end()) {
                 res.push_back(e2);
             }
         }
@@ -730,7 +730,7 @@ vector<ObjId> getNeighbors(const ObjId& obj, const string& fieldName,
                     fields.insert(tmp.begin(), tmp.end());
                 }
             }
-            if(fields.find(fieldName) != fields.end()) {
+            if(fieldName == "*" || fields.find(fieldName) != fields.end()) {
                 res.push_back(e1);
             }
         }

--- a/pybind11/helper.cpp
+++ b/pybind11/helper.cpp
@@ -16,7 +16,9 @@
 
 #include <memory>
 #include <stdexcept>
+#include <unordered_set>
 #include <csignal>
+#include <algorithm>
 
 #include <pybind11/functional.h>
 #include <pybind11/numpy.h>
@@ -31,6 +33,11 @@ namespace py = pybind11;
 
 #include "../basecode/header.h"
 #include "../basecode/global.h"
+#include "../msg/OneToOneMsg.h"
+#include "../msg/OneToAllMsg.h"
+#include "../msg/SingleMsg.h"
+#include "../msg/SparseMsg.h"
+#include "../msg/DiagonalMsg.h"
 
 #include "../builtins/Variable.h"
 #include "../mpi/PostMaster.h"
@@ -359,16 +366,16 @@ void mooseReinit()
 /* ----------------------------------------------------------------------------*/
 void mooseStart(double runtime, bool notify = false)
 {
-  // TODO: handle keyboard interrupt on _WIN32
+    // TODO: handle keyboard interrupt on _WIN32
 #if !defined(_WIN32)
-  // Credit:
-  // http://stackoverflow.com/questions/1641182/how-can-i-catch-a-ctrl-c-event-c
+    // Credit:
+    // http://stackoverflow.com/questions/1641182/how-can-i-catch-a-ctrl-c-event-c
     struct sigaction sigHandler;
     sigHandler.sa_handler = handleKeyboardInterrupts;
     sigemptyset(&sigHandler.sa_mask);
     sigHandler.sa_flags = 0;
     sigaction(SIGINT, &sigHandler, NULL);
-#endif    
+#endif
     getShellPtr()->doStart(runtime, notify);
 }
 
@@ -532,7 +539,7 @@ string mooseClassDoc(const string& className)
 
     for(string f : {"value", "lookup", "src", "dest", "shared", "field"})
         ss << mooseClassFieldsDoc(cinfo, f, "");
-    
+
     return ss.str();
 }
 
@@ -576,55 +583,178 @@ vector<string> mooseLe(const ObjId& obj)
     return chPaths;
 }
 
-vector<ObjId> mooseListMsg(const ObjId& obj)
+vector<ObjId> mooseListMsg(const ObjId& obj, int type)
 {
     vector<ObjId> res;
-    auto inmsgs = Field<vector<ObjId>>::get(obj, "msgIn");
-    for(const auto inobj : inmsgs) {
-        const Msg* msg = Msg::getMsg(inobj);
-        if(!msg) {
-            cerr << "No Msg found on " << obj.path() << endl;
-            continue;
+    if(type != 0) {  // Only for 0 skip INCOMING, all other cases keep it
+        auto inmsgs = Field<vector<ObjId>>::get(obj, "msgIn");
+        for(const auto inobj : inmsgs) {
+            const Msg* msg = Msg::getMsg(inobj);
+            if(!msg) {
+                cerr << "No incoming Msg found on " << obj.path() << endl;
+                continue;
+            }
+            res.push_back(msg->mid());
         }
-        res.push_back(msg->mid());
     }
-    auto outmsgs = Field<vector<ObjId>>::get(obj, "msgOut");
-    for(const auto outobj : outmsgs) {
-        const Msg* msg = Msg::getMsg(outobj);
-        res.push_back(msg->mid());
+    if(type != 1) {  // Only for 1 skip OUTGOING, all other cases keep it
+        auto outmsgs = Field<vector<ObjId>>::get(obj, "msgOut");
+        for(const auto outobj : outmsgs) {
+            const Msg* msg = Msg::getMsg(outobj);
+            if(!msg) {
+                cerr << "No outgoing Msg found on " << obj.path() << endl;
+                continue;
+            }
+            res.push_back(msg->mid());
+        }
     }
     return res;
 }
 
-string mooseShowMsg(const ObjId& obj)
+string mooseShowMsg(const ObjId& obj, int type)
 {
     stringstream ss;
-    ss << "INCOMING:" << endl;
-    auto inmsgs = Field<vector<ObjId>>::get(obj, "msgIn");
-    for(const auto inobj : inmsgs) {
-        const Msg* msg = Msg::getMsg(inobj);
-        if(!msg) {
-            cerr << "No Msg found on " << obj.path() << endl;
-            continue;
+    if(type != 0) {  // Only for 0 skip INCOMING, all other cases keep it
+        ss << "INCOMING:" << endl;
+        auto inmsgs = Field<vector<ObjId>>::get(obj, "msgIn");
+        for(const auto inobj : inmsgs) {
+            const Msg* msg = Msg::getMsg(inobj);
+            if(!msg) {
+                cerr << "No incoming Msg found on " << obj.path() << endl;
+                continue;
+            }
+            ObjId left, right;
+            vector<string> lfields, rfields;
+            left = msg->getE2();
+            if(left != obj) {
+                right = left;
+                left = obj;
+                rfields = msg->getSrcFieldsOnE2();
+                lfields = msg->getDestFieldsOnE1();
+            }
+            else {
+                right = msg->getE1();
+                rfields = msg->getSrcFieldsOnE1();
+                lfields = msg->getDestFieldsOnE2();
+            }
+
+            ss << fmt::format("  {0}, [{1}] <-- {2}, [{3}]\n", left.path(),
+                              moose::vectorToCSV<string>(lfields), right.path(),
+                              moose::vectorToCSV<string>(rfields));
         }
-        ss << fmt::format("  {0}, [{1}] <-- {2}, [{3}]\n", msg->getE2().path(),
-                          moose::vectorToCSV<string>(msg->getDestFieldsOnE2()),
-                          msg->getE1().path(),
-                          moose::vectorToCSV<string>(msg->getSrcFieldsOnE1()));
+        ss << endl;
     }
-    ss << endl;
-    auto outmsgs = Field<vector<ObjId>>::get(obj, "msgOut");
-    ss << "OUTGOING:" << endl;
-    for(const auto outobj : outmsgs) {
-        const Msg* msg = Msg::getMsg(outobj);
-        if(!msg) {
-            cerr << "No Msg found on " << obj.path() << endl;
-            continue;
+    if(type != 1) {  // Only for 1 skip OUTGOING, all other cases keep it
+        auto outmsgs = Field<vector<ObjId>>::get(obj, "msgOut");
+        ss << "OUTGOING:" << endl;
+        for(const auto outobj : outmsgs) {
+            const Msg* msg = Msg::getMsg(outobj);
+            if(!msg) {
+                cerr << "No outgoing Msg found on " << obj.path() << endl;
+                continue;
+            }
+            ObjId left, right;
+            vector<string> lfields, rfields;
+            left = msg->getE1();
+            if(left != obj) {
+                right = left;
+                left = obj;
+                lfields = msg->getSrcFieldsOnE2();
+                rfields = msg->getDestFieldsOnE1();
+            }
+            else {
+                right = msg->getE2();
+                lfields = msg->getSrcFieldsOnE1();
+                rfields = msg->getDestFieldsOnE2();
+            }
+            if(msg->getE1() == obj) {
+                ss << fmt::format("  {0}, [{1}] --> {2}, [{3}]\n", left.path(),
+                                  moose::vectorToCSV<string>(lfields),
+                                  right.path(),
+                                  moose::vectorToCSV<string>(rfields));
+            }
         }
-        ss << fmt::format("  {0}, [{1}] --> {2}, [{3}]\n", msg->getE1().path(),
-                          moose::vectorToCSV<string>(msg->getSrcFieldsOnE1()),
-                          msg->getE2().path(),
-                          moose::vectorToCSV<string>(msg->getDestFieldsOnE2()));
     }
     return ss.str();
+}
+
+vector<ObjId> getNeighbors(const ObjId& obj, const string& fieldName,
+                           string msgType, vector<ObjId> msgList, int direction)
+{
+    vector<ObjId> res;
+    for(const auto mobj : msgList) {
+        const Msg* msg = Msg::getMsg(mobj);
+        if(!msg) {
+            continue;
+        }
+        if(msgType != "") {
+	    std::transform(msgType.begin(), msgType.end(), msgType.begin(), ::tolower);
+            if((msgType == "onetoone" && typeid(*msg) != typeid(OneToOneMsg)) ||
+               (msgType == "onetoall" && typeid(*msg) != typeid(OneToAllMsg)) ||
+               (msgType == "diagonal" && typeid(*msg) != typeid(DiagonalMsg)) ||
+               (msgType == "single" && typeid(*msg) != typeid(SingleMsg)) ||
+               (msgType == "sparse" && typeid(*msg) != typeid(SparseMsg))) {
+                continue;
+            }
+        }
+        Id e1 = msg->getE1();
+        Id e2 = msg->getE2();
+        unordered_set<string> fields;
+        if(obj.id == e1) {
+            if(direction == 1) {
+                vector<string> tmp = msg->getDestFieldsOnE1();
+                fields.insert(tmp.begin(), tmp.end());
+            }
+            else {
+                vector<string> tmp = msg->getSrcFieldsOnE1();
+                fields.insert(tmp.begin(), tmp.end());
+                if(direction != 0) {  // both directions - dest and src
+                    tmp = msg->getDestFieldsOnE1();
+                    fields.insert(tmp.begin(), tmp.end());
+                }
+            }
+            if(fields.find(fieldName) != fields.end()) {
+                res.push_back(e2);
+            }
+        }
+        else {
+            if(direction == 1) {
+                vector<string> tmp = msg->getDestFieldsOnE2();
+                fields.insert(tmp.begin(), tmp.end());
+            }
+            else {
+                vector<string> tmp = msg->getSrcFieldsOnE2();
+                fields.insert(tmp.begin(), tmp.end());
+                if(direction != 0) {  // both directions - dest and src
+                    tmp = msg->getDestFieldsOnE2();
+                    fields.insert(tmp.begin(), tmp.end());
+                }
+            }
+            if(fields.find(fieldName) != fields.end()) {
+                res.push_back(e1);
+            }
+        }
+    }
+    return res;
+}
+
+vector<ObjId> mooseNeighbors(const ObjId& obj, const string& fieldName,
+                             const string& msgType, int direction)
+{
+    vector<ObjId> res;
+    if(direction == 1) {
+        auto inmsgs = Field<vector<ObjId>>::get(obj, "msgIn");
+        res = getNeighbors(obj, fieldName, msgType, inmsgs, direction);
+    }
+    else {
+        auto outmsgs = Field<vector<ObjId>>::get(obj, "msgOut");
+        res = getNeighbors(obj, fieldName, msgType, outmsgs, direction);
+        if(direction != 0) {
+            auto inmsgs = Field<vector<ObjId>>::get(obj, "msgIn");
+            vector<ObjId> tmp =
+                getNeighbors(obj, fieldName, msgType, inmsgs, direction);
+            res.insert(res.end(), tmp.begin(), tmp.end());
+        }
+    }
+    return res;
 }

--- a/pybind11/helper.h
+++ b/pybind11/helper.h
@@ -223,8 +223,32 @@ string mooseDoc(const string& string);
 
 vector<string> mooseLe(const ObjId& obj);
 
-string mooseShowMsg(const ObjId& obj);
+/** Returns a formatted string showing the messages on object `obj`.
+    `type` == 0 for outgoing messages,
+    `type` == 1 for incoming messages,
+    `type` == 2 for all messages.
+*/
+string mooseShowMsg(const ObjId& obj, int type=2);
 
-vector<ObjId> mooseListMsg(const ObjId& obj);
+/** Returns a vector of the messages on object `obj`.
+    `type` == 0 for outgoing messages,
+    `type` == 1 for incoming messages,
+    `type` == 2 for all messages.
+*/
+vector<ObjId> mooseListMsg(const ObjId& obj, int direction=2);
+
+/** Returns a vector of neighboring elements of `obj' connected to its field
+`fieldName`, by messages of type `msgType`, and in direction `direction`.
+`direction`=0 for outgoing,
+`direction`=1 for incoming,
+`direction`=2 for both.
+
+msgType should specify the class of message: "Single", "OneToOne",
+"OneToAll", "Diagonal", and "Sparse", of "" for all types of
+messages. Default is "".
+
+   
+ */
+vector<ObjId> mooseNeighbors(const ObjId& obj, const string& fieldName, const string& msgType="", int direction=2);
 
 #endif /* end of include guard: HELPER_H */

--- a/pybind11/pymoose.cpp
+++ b/pybind11/pymoose.cpp
@@ -441,7 +441,7 @@ PYBIND11_MODULE(_moose, m)
     m.def("le", &mooseLe);
     m.def("showmsg", &mooseShowMsg);
     m.def("listmsg", &mooseListMsg);
-
+    m.def("neighbors", &mooseNeighbors);
     m.def("loadModelInternal", &loadModelInternal);
 
     m.def("getFieldNames", &mooseGetFieldNames);

--- a/python/moose/__init__.py
+++ b/python/moose/__init__.py
@@ -778,7 +778,7 @@ def showmsg(el, direction=ALLMSG):
     print(_moose.showmsg(_moose.element(el), direction))
 
 
-def neighbors(el, field, msgtype='', direction=ALLMSG):
+def neighbors(el, field='*', msgtype='', direction=ALLMSG):
     """Get a list of neighbors connected on the specifield field
 
     Parameters
@@ -786,8 +786,9 @@ def neighbors(el, field, msgtype='', direction=ALLMSG):
     el: melement/vec/str
     el : melement/vec/str
         Object whose messages are to be displayed.
-    field: str
-        Name of the field on which to look for connections.
+    field: str {'*'}
+        Name of the field on which to look for connections. If  '*' (default)
+        get all neighbors connected on all fields.
     msgtype: str {'', 'Single', 'OneToOne', 'OneToAll', 'Sparse', 'Diagonal'}
         If specified, select neighbors connected by this type of message only.
         This is case-insensitive.


### PR DESCRIPTION
In pymoose some enhancement of API
* showmsg and listmsg
  - Added a second argument `direction` of type int.
    - direction = 0 for outgoing messages (0=O)
    - direction = 1 for incoming messages (1=I)
    - direction = 2 for all messages
  - Also added named constants OUTMSG, INMSG, ALLMSG for these message directions
  - Fixed a long-standing bug that printed incoming messages under outgoing message header.
* showfield(s)
  - Removed return statements so the terminal does not get cluttered by
  the redundant return string.
  - Created a list of system fields avoid printing fields unnecessary for the user. These can be retrieved by the new function `sysfields(element)`.
* Added new function `neighbors(element, field, msgtype, direction)` to retrieve the list of neighbor elements connected via messages on a field. This will simplify building and traversing object graph by connections.