### PR TITLE
Important regression fixes in NeuroML reader, pymoose, and tests

### DIFF
--- a/docs/source/install/AppleM1Build.md
+++ b/docs/source/install/AppleM1Build.md
@@ -20,4 +20,4 @@
 micromamba create -n moose numpy matplotlib vpython lxml meson ninja meson-python gsl setuptools pybind11[global] pkg-config -c conda-forge
 ```
 - Activate the moose environment: `micromamba activate moose`
-- Install moose from github: `pip install git+https://github.com/BhallaLab/moose-core.git`
+- Install moose from github: `pip install git+https://github.com/MooseNeuro/moose-core.git`

--- a/docs/source/install/INSTALL.md
+++ b/docs/source/install/INSTALL.md
@@ -62,10 +62,10 @@ Briefly,
    - python-setuptools
    - pkg-config
 
-2. Now use `pip` to download and install `pymoose` from the [github repository](https://github.com/BhallaLab/moose-core).
+2. Now use `pip` to download and install `pymoose` from the [github repository](https://github.com/MooseNeuro/moose-core).
 
 ```
-$ pip install git+https://github.com/BhallaLab/moose-core --user
+$ pip install git+https://github.com/MooseNeuro/moose-core --user
 ```
 
 This will install the `master` branch of MOOSE. If you want a specific fork/branch, modify the address:

--- a/docs/source/install/UbuntuBuild.md
+++ b/docs/source/install/UbuntuBuild.md
@@ -9,17 +9,17 @@ sudo apt install build-essential
 
 1. Install the dependencies
 ```
-sudo apt-get install ninja meson pkg-config python-pip python-numpy libgsl-dev g++ pybind11 
+sudo apt-get install ninja meson pkg-config python-pip python-numpy libgsl-dev g++ pybind11 libz-dev
 pip install meson-python
 pip install python-libsbml
 pip install pyneuroml
 pip install vpython
 ```
 
-2. Now use `pip` to download and install `pymoose` from the [github repository](https://github.com/BhallaLab/moose-core).
+2. Now use `pip` to download and install `pymoose` from the [github repository](https://github.com/MooseNeuro/moose-core).
 
 ```
-$ pip install git+https://github.com/BhallaLab/moose-core --user
+$ pip install git+https://github.com/MooseNeuro/moose-core --user
 ```
 
 ## Building with conda or variants
@@ -40,7 +40,7 @@ conda activate moose
 ## After the above steps, for both system Python and conda environment
 4. Clone `moose-core` source code using git
 ```
-    $ git clone https://github.com/BhallaLab/moose-core --depth 50 
+    $ git clone https://github.com/MooseNeuro/moose-core --depth 50 
 ```
 5. Build moose
 ```
@@ -104,7 +104,7 @@ Install the required dependencies and download the latest source code of moose
 from github.
 
 ```
-    $ git clone https://github.com/BhallaLab/moose-core --depth 50 
+    $ git clone https://github.com/MooseNeuro/moose-core --depth 50 
     $ cd moose-core
     $ meson setup --wipe _build --prefix=`pwd`/_build_install -Duse_mpi=false -Dbuildtype=release
     $ ninja -v -C _build 

--- a/docs/source/install/WSLGuide.md
+++ b/docs/source/install/WSLGuide.md
@@ -42,7 +42,7 @@ micromamba activate moose
 - Build and install pymoose
 
 ```
-pip install git+https://github.com/BhallaLab/moose-core.git
+pip install git+https://github.com/MooseNeuro/moose-core.git
 ```
 
 You need to do the above only once. After that, each time to use moose, open WSL Ubuntu terminal and do the following

--- a/docs/source/install/WindowsBuild.md
+++ b/docs/source/install/WindowsBuild.md
@@ -35,14 +35,14 @@ conda activate moose
 
 ## Build and install moose using `pip`
 ```
-pip install git=https://github.com/BhallaLab/moose-core
+pip install git=https://github.com/MooseNeuro/moose-core
 ```
 
 ## Build moose for development
 *Note: The commands below are designed for PowerShell.*
 * Get moose source code by cloning `moose-core` source code using git
 ```
-git clone https://github.com/BhallaLab/moose-core --depth 50 
+git clone https://github.com/MooseNeuro/moose-core --depth 50 
 ```
 
 * If you have not already set the path to LLVM binaries, run 

--- a/pybind11/pymoose.cpp
+++ b/pybind11/pymoose.cpp
@@ -187,8 +187,9 @@ vector<ObjId> getChildren(const ObjId &oid)
     vector<Id> children;
     Neutral::children(oid.eref(), children);
     vector<ObjId> res;
-    std::transform(children.begin(), children.end(), res.begin(),
-                   [](const Id& id) { return ObjId(id); });
+    for(auto child : children) {
+        res.push_back(ObjId(child));
+    }
     return res;
 }
 

--- a/python/moose/__init__.py
+++ b/python/moose/__init__.py
@@ -23,6 +23,7 @@ References:
 import sys
 import pydoc
 import os
+import warnings
 
 import moose._moose as _moose
 from moose import model_utils
@@ -280,6 +281,12 @@ def delete(arg):
     -------
     None, Raises ValueError if given path/object does not exists.
     """
+    if isinstance(arg, str) and not exists(arg):
+        warnings.warn(
+            f'Attempt to delete nonexistent path {arg}: ignoring',
+            warnings.RuntimeWarning,
+        )
+        return
     _moose.delete(arg)
 
 
@@ -467,7 +474,7 @@ def setCwe(arg):
 
 def ce(arg):
     """Set the current element to `arg`
-    
+
     This is an alias for ``setCwe``
     """
     _moose.setCwe(arg)

--- a/python/moose/neuroml2/reader.py
+++ b/python/moose/neuroml2/reader.py
@@ -53,6 +53,45 @@ PREDEFINED_RATEFN_MAP = {
 }
 
 
+PREDEFINED_GATE_DYN_PARAMS = [
+    "forward_rate",
+    "reverse_rate",
+    "time_course",
+    "steady_state",
+]
+
+VOLTAGE_DEP_COMPONENTTYPES = [
+    "baseVoltageDepTime",
+    "fixedTimeCourse",
+    "baseVoltageDepRate",
+    "baseHHRate",
+    "HHExpRate",
+    "HHExpLinearRate",
+    "baseVoltageDepVariable",
+    "baseHHVariable",
+    "HHExpVariable",
+    "HHSigmoidVariable",
+    "HHExpLinearVariable",
+]
+
+VOLTAGE_CA_DEP_COMPONENTTYPES = [
+    "baseVoltageConcDepRate",
+    "baseVoltageConcDepVariable" "baseVoltageConcDepTime",
+]
+
+
+def pythonize_expr(expr):
+    """Convert NeuroML2 expression `expr` into valid Python"""
+    py_expr = (
+        expr.replace(".neq.", "!=")
+        .replace(".eq.", "==")
+        .replace(".gt.", ">")
+        .replace(".lt.", "<")
+        .replace("^", "**")
+    )
+    return py_expr
+
+
 def array_eval_component(comp_type, req_vars, params={}):
     """Use numpy vectorization for faster evaluation of component formula.
 
@@ -108,6 +147,7 @@ def array_eval_component(comp_type, req_vars, params={}):
     # print("#" * 80, "\n", exec_str, "\n", "#" * 80, "\n")
     exec_str = "\n".join(exec_str)
     # print("*" * 80, "\n", exec_str, "\n", "*" * 80)
+    logger_.debug(f'Excuting string "{exec_str}"\nlocals: {local_vars}')
     exec(exec_str, np.__dict__, local_vars)
     return local_vars["return_vals"]
 
@@ -149,6 +189,36 @@ def _gates_sorted(all_gates):
             sortedGates.append(allGatesDict.get(gid))
         return sortedGates
     return all_gates
+
+
+def _isVarInExpr(expr, var):
+    """Returns `True` if variable `var` is present in the expression `expr`.
+
+    Paramaters
+    ----------
+    expr: str
+        expression to check
+    var: str
+        variable id to look for
+    Returns
+    -------
+    bool:
+        `True` is `var` is in `expr`, otherwise `False`
+    """
+    parsed = ast.parse(expr)
+    for node in ast.walk(parsed):
+        if isinstance(node, ast.Name):
+            if node.id == var:
+                return True
+    return False
+
+
+def _getPredefinedGateDynamicParams(ngate):
+    """Returns a dict of predefined parameters for gate dynamics listed in `PREDEFINED_GATE_DYN_PARAMS`"""
+    return {
+        param: getattr(ngate, param, None)
+        for param in PREDEFINED_GATE_DYN_PARAMS
+    }
 
 
 def _isConcDep(ct):
@@ -922,16 +992,23 @@ class NML2Reader(object):
             ComponentType object
 
         """
+        if ct.extends in VOLTAGE_CA_DEP_COMPONENTTYPES:
+            return True
+
+        ca_id = 'caConc'  # the name of the variable representing [Ca2+]
         for dyn in ct.Dynamics:
-            for dv in dyn.DerivedVariable + dyn.ConditionalDerivedVariable:
-                parsed = ast.parse(dv.value)
-                # If any identifier (represented by class ast.Name) in
-                # the derived variable expression is "caConc", the
-                # gate is Ca concentration dependent.
-                for node in ast.walk(parsed):
-                    if isinstance(node, ast.Name):
-                        if node.id == "caConc":
-                            return True
+            for dv in dyn.DerivedVariable:
+                if _isVarInExpr(pythonize_expr(dv.value), ca_id):
+                    return True
+            for cdv in dyn.ConditionalDerivedVariable:
+                for case_ in cdv.Case:
+                    if (
+                        (case_.condition is not None)
+                        and _isVarInExpr(
+                            pythonize_expr(case_.condition), ca_id
+                        )
+                    ) or _isVarInExpr(pythonize_expr(case_.value), ca_id):
+                        return True
         return False
 
     def isDynamicsVoltageDependent(self, ct):
@@ -946,17 +1023,27 @@ class NML2Reader(object):
         ct : nml.ComponentType
             ComponentType object
 
+        Returns
+        -------
+        bool:
+            `True` if the variable identifier 'v' appears anywhere in
+            the expressions for the dynamics, `False` otherwise.
+
         """
+        v_var = 'v'
         for dyn in ct.Dynamics:
-            for dv in dyn.DerivedVariable + dyn.ConditionalDerivedVariable:
-                parsed = ast.parse(dv.value)
-                # If any identifier (represented by class ast.Name) in
-                # the derived variable expression is "caConc", the
-                # gate is Ca concentration dependent.
-                for node in ast.walk(parsed):
-                    if isinstance(node, ast.Name):
-                        if node.id == "v":
-                            return True
+            for dv in dyn.DerivedVariable:
+                if _isVarInExpr(pythonize_exp(dv.value), v_var):
+                    return True
+            for cdv in dyn.ConditionalDerivedVariable:
+                for case_ in cdv.Case:
+                    if (
+                        (case_.condition is not None)
+                        and _isVarInExpr(
+                            pythonize_expr(case_.condition), v_var
+                        )
+                    ) or _isVarInExpr(pythonize_expr(case_.value), v_var):
+                        return True
         return False
 
     def isDynamicsVoltageCaDependent(self, ct):
@@ -979,22 +1066,29 @@ class NML2Reader(object):
             ComponentType object
 
         """
+        ca_var = 'caConc'
+        v_var = 'v'
         ca_dep = False
         v_dep = False
         for dyn in ct.Dynamics:
-            for dv in dyn.DerivedVariable + dyn.ConditionalDerivedVariable:
-                parsed = ast.parse(dv.value)
-                # If any identifier (represented by class ast.Name) in
-                # the derived variable expression is "caConc", the
-                # gate is Ca concentration dependent. If any
-                # identifier is "v", it is voltage dependent.
-                for node in ast.walk(parsed):
-                    if isinstance(node, ast.Name):
-                        if node.id == "caConc":
-                            ca_dep = True
-                        if node.id == "v":
-                            v_dep = True
-        return (ca_dep is True) and (v_dep is True)
+            for dv in dyn.DerivedVariable:
+                expr = pythonize_expr(dv.value)
+                ca_dep = _isVarInExpr(expr, ca_var)
+                v_dep = _isVarInExpr(expr, v_var)
+            for dv in dyn.ConditionalDerivedVariable:
+                for case_ in dv.Case:
+                    if case_.condition is None:
+                        cond_expr = ''
+                    else:
+                        cond_expr = pythonize_expr(case_.condition)
+                    v_expr = pythonize_expr(case_.value)
+                    ca_dep = _isVarInExpr(cond_expr, ca_var) or _isVarInExpr(
+                        v_expr, ca_var
+                    )
+                    v_dep = _isVarInExpr(cond_expr, v_var) or _isVarInExpr(
+                        v_expr, v_var
+                    )
+        return ca_dep and v_dep
 
     def isChannelCaDependent(self, chan):
         """Returns True if `chan` is dependent on calcium concentration.
@@ -1011,23 +1105,8 @@ class NML2Reader(object):
 
         """
         for gate in chan.gates + chan.gate_hh_rates:
-            dynamics = [
-                gate.forward_rate,
-                gate.reverse_rate,
-                gate.time_course,
-                gate.steady_state,
-            ]
-            for dyn in dynamics:
-                if dyn is not None:
-                    ct = self.getComponentType(dyn)
-                    if ct is None:
-                        continue
-                    if (
-                        ct.extends == "baseVoltageConcDepRate"
-                        or ct.extends == "baseVoltageConcDepVariable"
-                    ):
-                        if self.isDynamicsCaDependent(ct):
-                            return True
+            if self.isGateCaDependent(gate):
+                return True
         return False
 
     def isChannel2D(self, chan):
@@ -1059,16 +1138,14 @@ class NML2Reader(object):
             Gate description element in neuroml
 
         """
-        dynamics = [
-            getattr(ngate, "forward_rate", None),
-            getattr(ngate, "reverse_rate", None),
-            getattr(ngate, "time_course", None),
-            getattr(ngate, "steady_state", None),
-        ]
-        for dyn in dynamics:
+        dynamics = _getPredefinedGateDynamicParams(ngate)
+        for _, dyn in dynamics.items():
             if dyn is not None:
                 ct = self.getComponentType(dyn)
-                if (ct is not None) and self.isDynamicsCaDependent(ct):
+                if (ct is not None) and (
+                    (ct.extends in VOLTAGE_CA_DEP_COMPONENTTYPES)
+                    or self.isDynamicsCaDependent(ct)
+                ):
                     return True
         return False
 
@@ -1081,16 +1158,15 @@ class NML2Reader(object):
             Gate description element in neuroml
 
         """
-        dynamics = [
-            getattr(ngate, "forward_rate", None),
-            getattr(ngate, "reverse_rate", None),
-            getattr(ngate, "time_course", None),
-            getattr(ngate, "steady_state", None),
-        ]
-        for dyn in dynamics:
+        dynamics = _getPredefinedGateDynamicParams(ngate)
+        for _, dyn in dynamics.items():
             if dyn is not None:
+                if dyn.type in VOLTAGE_DEP_COMPONENTTYPES:
+                    return True
                 ct = self.getComponentType(dyn)
-                if (ct is not None) and self.isDynamicsCaDependent(ct):
+                if (ct is not None) and (
+                    ct.extends in VOLTAGE_DEP_COMPONENTTYPES + VOLTAGE_CA_DEP_COMPONENTTYPES
+                ):
                     return True
         return False
 
@@ -1104,22 +1180,13 @@ class NML2Reader(object):
             Gate description element in neuroml
 
         """
-        dynamics = [
-            getattr(ngate, "forward_rate", None),
-            getattr(ngate, "reverse_rate", None),
-            getattr(ngate, "time_course", None),
-            getattr(ngate, "steady_state", None),
-        ]
-        for dyn in dynamics:
+        dynamics = _getPredefinedGateDynamicParams(ngate)
+        for _, dyn in dynamics.items():
             if dyn is not None:
                 ct = self.getComponentType(dyn)
-                if (
-                    (ct is not None)
-                    and (
-                        ct.extends == "baseVoltageConcDepRate"
-                        or ct.extends == "baseVoltageConcDepVariable"
-                    )
-                    and self.isDynamicsVoltageCaDependent(ct)
+                if (ct is not None) and (
+                    (ct.extends in VOLTAGE_CA_DEP_COMPONENTTYPES)
+                    or self.isDynamicsVoltageCaDependent(ct)
                 ):
                     return True
         return False
@@ -1227,7 +1294,17 @@ class NML2Reader(object):
         return q10_scale
 
     def updateHHGate(
-        self, ngate, mgate, mchan, vmin, vmax, vdivs, useInterpolation=True
+        self,
+        ngate,
+        mgate,
+        mchan,
+        vmin,
+        vmax,
+        vdivs,
+        cmin=1e-9,
+        cmax=1.0,
+        cdivs=3000,
+        useInterpolation=True,
     ):
         """Update moose `HHGate` mgate from NeuroML gate description
         element `ngate`.
@@ -1269,14 +1346,21 @@ class NML2Reader(object):
         q10_scale = self._computeQ10Scale(ngate)
         alpha, beta, tau, inf = (None, None, None, None)
         param_tabs = {}
-        vtab = np.linspace(vmin, vmax, vdivs)
+        if self.isGateVoltageDependent(ngate):
+            vtab = np.linspace(vmin, vmax, vdivs)
+        else:
+            vtab = None
+        if self.isGateCaDependent(ngate):
+            ctab = np.linspace(cmin, cmax, cdivs)
+        else:
+            ctab = None
         # First try computing alpha and beta from fwd and rev rate
         # specs. Set the gate tables using alpha and beta by default.
         fwd = ngate.forward_rate
         rev = ngate.reverse_rate
         if (fwd is not None) and (rev is not None):
-            alpha = self.calculateRateFn(fwd, vtab)
-            beta = self.calculateRateFn(rev, vtab)
+            alpha = self.calculateRateFn(fwd, vtab, ctab=ctab)
+            beta = self.calculateRateFn(rev, vtab, ctab=ctab)
             param_tabs = {"alpha": Q_(alpha, "1/s"), "beta": Q_(beta, "1/s")}
 
         # Beware of a peculiar cascade of evaluation below: In some
@@ -1293,6 +1377,7 @@ class NML2Reader(object):
             tau = self.calculateRateFn(
                 ngate.time_course,
                 vtab,
+                ctab=ctab,
                 param_tabs=param_tabs,
             )
         elif (alpha is not None) and (beta is not None):
@@ -1305,6 +1390,7 @@ class NML2Reader(object):
             inf = self.calculateRateFn(
                 ngate.steady_state,
                 vtab,
+                ctab=ctab,
                 param_tabs=param_tabs,
             )
         elif (alpha is not None) and (beta is not None):
@@ -1630,6 +1716,7 @@ class NML2Reader(object):
         logger_.info(f"{self.filename}: Importing the ion channels")
 
         for chan in doc.ion_channel + doc.ion_channel_hhs:
+            logger_.debug(f'Processing channel {chan.id}')
             if self.isPassiveChan(chan):
                 mchan = self.createPassiveChannel(chan)
             elif self.isChannel2D(chan):

--- a/tests/core/test_GraupnerBrunel2012_STDPfromCaPlasticity.py
+++ b/tests/core/test_GraupnerBrunel2012_STDPfromCaPlasticity.py
@@ -12,8 +12,6 @@ import moose
 print( 'Using moose from %s' % moose.__file__ )
 import numpy as np
 
-moose.seed( 10 )
-
 def test_GB2012_STDP():
     """
     Simulate a pseudo-STDP protocol and plot the STDP kernel
@@ -21,6 +19,8 @@ def test_GB2012_STDP():
 
     Author: Aditya Gilra, NCBS, Bangalore, October, 2014.
     """
+
+    moose.seed( 10 )
 
     # ###########################################
     # Neuron models

--- a/tests/core/test_Xchan1.py
+++ b/tests/core/test_Xchan1.py
@@ -84,14 +84,14 @@ def makeModel():
     stoich.compartment = compartment
     stoich.ksolve = ksolve
     stoich.dsolve = dsolve
-    stoich.path = "/model/compartment/##"
+    stoich.reacSystemPath = "/model/compartment/##"
     assert (dsolve.numPools == 2)
 
     estoich = moose.Stoich('/model/endo/stoich')
     estoich.compartment = endo
     estoich.ksolve = eksolve
     estoich.dsolve = edsolve
-    estoich.path = "/model/endo/##"
+    estoich.reacSystemPath = "/model/endo/##"
     assert (edsolve.numPools == 2)
 
     edsolve.buildMeshJunctions(dsolve)

--- a/tests/core/test_Xdiff1.py
+++ b/tests/core/test_Xdiff1.py
@@ -76,14 +76,14 @@ def makeModel():
     stoich.compartment = compartment
     stoich.ksolve = ksolve
     stoich.dsolve = dsolve
-    stoich.path = "/model/compartment/##"
+    stoich.reacSystemPath = "/model/compartment/##"
     assert( dsolve.numPools == 2 )
 
     estoich = moose.Stoich( '/model/endo/stoich' )
     estoich.compartment = endo
     estoich.ksolve = eksolve
     estoich.dsolve = edsolve
-    estoich.path = "/model/endo/##"
+    estoich.reacSystemPath = "/model/endo/##"
     assert( edsolve.numPools == 1 )
 
     edsolve.buildMeshJunctions( dsolve )

--- a/tests/core/test_Xenz1.py
+++ b/tests/core/test_Xenz1.py
@@ -73,7 +73,7 @@ def makeModel():
     stoich.compartment = compartment
     stoich.ksolve = ksolve
     stoich.dsolve = dsolve
-    stoich.path = "/model/compartment/##"
+    stoich.reacSystemPath = "/model/compartment/##"
     assert( dsolve.numPools == 2 )
     sub.vec.concInit = subInit
     enzPool.vec.concInit = eInit
@@ -82,7 +82,7 @@ def makeModel():
     estoich.compartment = endo
     estoich.ksolve = eksolve
     estoich.dsolve = edsolve
-    estoich.path = "/model/endo/##"
+    estoich.reacSystemPath = "/model/endo/##"
     assert( edsolve.numPools == 3 )
 
     edsolve.buildMeshJunctions( dsolve )

--- a/tests/core/test_Xreacs2.py
+++ b/tests/core/test_Xreacs2.py
@@ -42,7 +42,7 @@ def test_xreac2():
     s1.compartment = moose.element( '/model/kinetics' )
     s1.ksolve = ks1
     s1.dsolve = ds1
-    s1.path = '/model/kinetics/##'
+    s1.reacSystemPath = '/model/kinetics/##'
 
     ks2 = moose.Ksolve( '/model/compartment_1/ksolve' )
     ds2 = moose.Dsolve( '/model/compartment_1/dsolve' )
@@ -50,7 +50,7 @@ def test_xreac2():
     s2.compartment = moose.element( '/model/compartment_1' )
     s2.ksolve = ks2
     s2.dsolve = ds2
-    s2.path = '/model/compartment_1/##'
+    s2.reacSystemPath = '/model/compartment_1/##'
 
     print(ds1)
     ds2.buildMeshJunctions( ds1 )

--- a/tests/core/test_Xreacs3.py
+++ b/tests/core/test_Xreacs3.py
@@ -64,7 +64,7 @@ def makeModel():
     stoich.compartment = compartment
     stoich.ksolve = ksolve
     stoich.dsolve = dsolve
-    stoich.path = "/model/compartment/##"
+    stoich.reacSystemPath = "/model/compartment/##"
     assert( dsolve.numPools == 2 )
     s.vec.concInit = [1.0]*num
 
@@ -72,7 +72,7 @@ def makeModel():
     estoich.compartment = endo
     estoich.ksolve = eksolve
     estoich.dsolve = edsolve
-    estoich.path = "/model/endo/##"
+    estoich.reacSystemPath = "/model/endo/##"
     assert( edsolve.numPools == 1 )
 
     edsolve.buildMeshJunctions( dsolve )

--- a/tests/core/test_Xreacs4.py
+++ b/tests/core/test_Xreacs4.py
@@ -53,7 +53,7 @@ def makeModel():
     stoich.compartment = compartment
     stoich.ksolve = ksolve
     stoich.dsolve = dsolve
-    stoich.path = "/model/compartment/##"
+    stoich.reacSystemPath = "/model/compartment/##"
     assert( dsolve.numPools == 2 )
     s.vec.concInit = [1.0]*num
 
@@ -61,7 +61,7 @@ def makeModel():
     estoich.compartment = endo
     estoich.ksolve = eksolve
     estoich.dsolve = edsolve
-    estoich.path = "/model/endo/##"
+    estoich.reacSystemPath = "/model/endo/##"
     assert( edsolve.numPools == 1 )
 
     edsolve.buildMeshJunctions( dsolve )

--- a/tests/core/test_Xreacs4a.py
+++ b/tests/core/test_Xreacs4a.py
@@ -53,7 +53,7 @@ def makeModel():
     stoich.compartment = compartment
     stoich.ksolve = ksolve
     stoich.dsolve = dsolve
-    stoich.path = "/model/compartment/##"
+    stoich.reacSystemPath = "/model/compartment/##"
     assert( dsolve.numPools == 1 )
     s.vec.concInit = [1.0]*num
 
@@ -61,7 +61,7 @@ def makeModel():
     estoich.compartment = endo
     estoich.ksolve = eksolve
     estoich.dsolve = edsolve
-    estoich.path = "/model/endo/##"
+    estoich.reacSystemPath = "/model/endo/##"
     assert( edsolve.numPools == 2 )
 
     edsolve.buildMeshJunctions( dsolve )

--- a/tests/core/test_Xreacs5.py
+++ b/tests/core/test_Xreacs5.py
@@ -57,7 +57,7 @@ def makeModel():
     stoich.compartment = compartment
     stoich.ksolve = ksolve
     stoich.dsolve = dsolve
-    stoich.path = "/model/compartment/##"
+    stoich.reacSystemPath = "/model/compartment/##"
     assert( dsolve.numPools == 2 )
     s.vec.concInit = [1.0]*num
 
@@ -65,7 +65,7 @@ def makeModel():
     estoich.compartment = endo
     estoich.ksolve = eksolve
     estoich.dsolve = edsolve
-    estoich.path = "/model/endo/##"
+    estoich.reacSystemPath = "/model/endo/##"
     assert( edsolve.numPools == 2 )
 
     edsolve.buildMeshJunctions( dsolve )

--- a/tests/core/test_Xreacs5a.py
+++ b/tests/core/test_Xreacs5a.py
@@ -59,7 +59,7 @@ def makeModel():
     stoich.compartment = compartment
     stoich.ksolve = ksolve
     stoich.dsolve = dsolve
-    stoich.path = "/model/compartment/##"
+    stoich.reacSystemPath = "/model/compartment/##"
     assert( dsolve.numPools == 2 )
     s.vec.concInit = [1.0]*num
 
@@ -67,7 +67,7 @@ def makeModel():
     estoich.compartment = endo
     estoich.ksolve = eksolve
     estoich.dsolve = edsolve
-    estoich.path = "/model/endo/##"
+    estoich.reacSystemPath = "/model/endo/##"
     assert( edsolve.numPools == 1 )
 
     edsolve.buildMeshJunctions( dsolve )

--- a/tests/core/test_Xreacs6.py
+++ b/tests/core/test_Xreacs6.py
@@ -8,7 +8,7 @@
 ## See the file COPYING.LIB for the full notice.
 #########################################################################
 
-
+import pytest
 import math
 import numpy as np
 import moose
@@ -55,7 +55,7 @@ def makeModel():
     stoich.compartment = compartment
     stoich.ksolve = ksolve
     stoich.dsolve = dsolve
-    stoich.path = "/model/compartment/##"
+    stoich.reacSystemPath = "/model/compartment/##"
     assert( dsolve.numPools == 4 )
     s.vec.concInit = [1.0]*num
     t.vec.concInit = [1.0]*num
@@ -64,7 +64,7 @@ def makeModel():
     estoich.compartment = endo
     estoich.ksolve = eksolve
     estoich.dsolve = edsolve
-    estoich.path = "/model/endo/##"
+    estoich.reacSystemPath = "/model/endo/##"
     assert( edsolve.numPools == 2 )
 
     edsolve.buildMeshJunctions( dsolve )
@@ -82,6 +82,7 @@ def almostEq( a, b ):
     #print a, b, (a-b)/(a+b)
     return abs(a-b)/(a+b) < 5e-5
 
+@pytest.mark.skip(reason="Crashes pytest on Windowswith: 'Windows fatal exception: access violation'")
 def test_xreac6():
     for i in range( 10, 18):
         moose.setClock( i, 0.01 )

--- a/tests/core/test_Xreacs7.py
+++ b/tests/core/test_Xreacs7.py
@@ -69,14 +69,14 @@ def makeModel():
     stoich.compartment = compartment
     stoich.ksolve = ksolve
     stoich.dsolve = dsolve
-    stoich.path = "/model/compartment/##"
+    stoich.reacSystemPath = "/model/compartment/##"
     assert( dsolve.numPools == 1 )
 
     estoich = moose.Stoich( '/model/endo/stoich' )
     estoich.compartment = endo
     estoich.ksolve = eksolve
     estoich.dsolve = edsolve
-    estoich.path = "/model/endo/##"
+    estoich.reacSystemPath = "/model/endo/##"
     assert( edsolve.numPools == 3 )
 
     edsolve.buildMeshJunctions( dsolve )

--- a/tests/core/test_Xreacs8.py
+++ b/tests/core/test_Xreacs8.py
@@ -65,7 +65,7 @@ def makeModel():
     stoich.compartment = compartment
     stoich.ksolve = ksolve
     stoich.dsolve = dsolve
-    stoich.path = "/model/compartment/##"
+    stoich.reacSystemPath = "/model/compartment/##"
     assert( dsolve.numPools == 2 )
     s.vec.concInit = [1.0]*num
 
@@ -73,7 +73,7 @@ def makeModel():
     estoich.compartment = endo
     estoich.ksolve = eksolve
     estoich.dsolve = edsolve
-    estoich.path = "/model/endo/##"
+    estoich.reacSystemPath = "/model/endo/##"
     assert( edsolve.numPools == 1 )
     edsolve.buildMeshJunctions( dsolve )
 

--- a/tests/core/test_api.py
+++ b/tests/core/test_api.py
@@ -3,6 +3,7 @@ __copyright__  = "Copyright 2019-, Dilawar Singh"
 __maintainer__ = "Dilawar Singh"
 __email__      = "dilawars@ncbs.res.in"
 
+
 import moose
 
 if moose._moose.__generated_by__ != "pybind11":
@@ -208,6 +209,7 @@ def test_elements():
     assert ze.isA['HHGate']
 
 def test_paths():
+    print('Testing paths')
     x = moose.Neutral('///x')
     assert x.path == '/x', x.path
 

--- a/tests/core/test_cylinder_diffusion_gsolve+dsolve.py
+++ b/tests/core/test_cylinder_diffusion_gsolve+dsolve.py
@@ -65,7 +65,7 @@ def makeModel():
     stoich.compartment = compartment
     stoich.ksolve = ksolve
     stoich.dsolve = dsolve
-    stoich.path = "/model/compartment/##"
+    stoich.reacSystemPath = "/model/compartment/##"
     assert( dsolve.numPools == 4 )
     a.vec.concInit = concA
     b.vec.concInit = concA / 5.0

--- a/tests/core/test_dose_response.py
+++ b/tests/core/test_dose_response.py
@@ -22,7 +22,7 @@ def setupSteadyState(simdt,plotDt):
     stoich = moose.Stoich( '/model/kinetics/stoich' )
     stoich.compartment = moose.element('/model/kinetics')
     stoich.ksolve = ksolve
-    stoich.path = "/model/kinetics/##"
+    stoich.reacSystemPath = "/model/kinetics/##"
     state = moose.SteadyState( '/model/kinetics/state' )
     moose.reinit()
     state.stoich = stoich

--- a/tests/core/test_expr_parser.py
+++ b/tests/core/test_expr_parser.py
@@ -256,7 +256,7 @@ def singleCompt(name, params):
     stoich.compartment = mod
 
     stoich.ksolve = ksolve
-    stoich.path = mod.path + '/##'
+    stoich.reacSystemPath = mod.path + '/##'
     print('REINIT AND START')
     moose.reinit()
     runtime += 100 + steptime * 2

--- a/tests/neuroml2/GranuleCell/GranPassiveCond.channel.nml
+++ b/tests/neuroml2/GranuleCell/GranPassiveCond.channel.nml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="ISO-8859-1"?>
+<neuroml xmlns="http://www.neuroml.org/schema/neuroml2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.neuroml.org/schema/neuroml2 https://raw.github.com/NeuroML/NeuroML2/development/Schemas/NeuroML2/NeuroML_v2beta4.xsd" id="GranPassiveCond">
+
+    <notes>ChannelML file containing a single Channel description</notes>
+
+    <ionChannel id="GranPassiveCond" conductance="10pS" type="ionChannelPassive">
+
+        <notes>Simple leak conductance for Granule cell</notes>
+                
+        <annotation>
+            <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+                <rdf:Description rdf:about="GranPassiveCond">
+                    
+                    <bqmodel:isDescribedBy xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+                        <rdf:Bag>
+                            <rdf:li>Maex, R and De Schutter, E. 
+            Synchronization of Golgi and Granule Cell Firing in a Detailed Network Model of the 
+            cerebellar Granule Cell Layer. J Neurophysiol, Nov 1998; 80: 2521 - 2537</rdf:li>
+                            <rdf:li rdf:resource="http://www.ncbi.nlm.nih.gov/pubmed/9819260"/>
+                        </rdf:Bag>
+                    </bqmodel:isDescribedBy>
+
+                </rdf:Description>
+            </rdf:RDF>
+        </annotation>
+                            
+    </ionChannel>
+
+</neuroml>

--- a/tests/neuroml2/GranuleCell/Gran_CaHVA_98.channel.nml
+++ b/tests/neuroml2/GranuleCell/Gran_CaHVA_98.channel.nml
@@ -1,0 +1,82 @@
+<?xml version="1.0" encoding="ISO-8859-1"?>
+<neuroml xmlns="http://www.neuroml.org/schema/neuroml2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.neuroml.org/schema/neuroml2 https://raw.github.com/NeuroML/NeuroML2/development/Schemas/NeuroML2/NeuroML_v2beta4.xsd" id="Gran_CaHVA_98">
+
+    <notes>A channel from Maex, R and De Schutter, E. Synchronization of Golgi and Granule Cell Firing in a 
+    Detailed Network Model of the Cerebellar Granule Cell Layer</notes>
+
+    <ionChannel id="Gran_CaHVA_98" conductance="10pS" type="ionChannelHH" species="ca">
+
+        <notes>A High Voltage Activated Ca2+ channel</notes>
+                
+        <annotation>
+            <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+                <rdf:Description rdf:about="Gran_CaHVA_98">
+                    
+                    <bqmodel:isDescribedBy xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+                        <rdf:Bag>
+                            <rdf:li>Maex, R and De Schutter, E. 
+           Synchronization of Golgi and Granule Cell Firing in a Detailed Network Model of the 
+           cerebellar Granule Cell Layer. J Neurophysiol, Nov 1998; 80: 2521 - 2537</rdf:li>
+                            <rdf:li rdf:resource="http://www.ncbi.nlm.nih.gov/pubmed/9819260"/>
+                        </rdf:Bag>
+                    </bqmodel:isDescribedBy>
+
+                
+                    <bqbiol:isVersionOf xmlns:bqbiol="http://biomodels.net/biology-qualifiers/">
+                        <rdf:Bag>
+                            <rdf:li>Calcium channels</rdf:li>
+                            <rdf:li rdf:resource="http://senselab.med.yale.edu/neurondb/channelGene2.aspx#table1"/>
+                        </rdf:Bag>
+                    </bqbiol:isVersionOf>
+
+                </rdf:Description>
+            </rdf:RDF>
+        </annotation>
+
+        <gate id="m" type="gateHHrates" instances="2">
+            <q10Settings type="q10ExpTemp" q10Factor="3" experimentalTemp="17.350264793 degC"/>
+            <!--Note: offset from ChannelML file incorporated into the midpoint of rates!!-->
+            <forwardRate type="HHSigmoidRate" rate="1600per_s" scale="0.01388888889V" midpoint="0.015V"/>
+            <reverseRate type="HHExpLinearRate" rate="100per_s" scale="-0.005V" midpoint="0.0011000000000000003V"/>
+        </gate>
+
+        <gate id="h" type="gateHHrates" instances="1">
+            <q10Settings type="q10ExpTemp" q10Factor="3" experimentalTemp="17.350264793 degC"/>
+            <!--Note: offset from ChannelML file incorporated into the midpoint of rates!!-->
+            <forwardRate type="Gran_CaHVA_98_h_alpha_rate"/>
+            <reverseRate type="Gran_CaHVA_98_h_beta_rate"/>
+        </gate>
+                            
+    </ionChannel>
+
+    <ComponentType name="Gran_CaHVA_98_h_alpha_rate" extends="baseVoltageDepRate">
+        <Constant name="TIME_SCALE" dimension="time" value="1 s"/>
+        <Constant name="VOLT_SCALE" dimension="voltage" value="1 V"/>
+        <Constant name="offset" dimension="voltage" value="0.010V"/>
+
+        <Dynamics>
+            <DerivedVariable name="V" dimension="none" value="(v - offset) / VOLT_SCALE"/>
+            <ConditionalDerivedVariable name="r" exposure="r" dimension="per_time">
+                <Case condition="V   .lt. ( -0.060 )" value="( 5.0 ) / TIME_SCALE"/>
+                <Case value="( 5 * (exp (-50 * (V - (-0.060))))) / TIME_SCALE"/>
+            </ConditionalDerivedVariable>
+        </Dynamics>
+
+    </ComponentType>
+
+    <ComponentType name="Gran_CaHVA_98_h_beta_rate" extends="baseVoltageDepRate">
+        <Constant name="TIME_SCALE" dimension="time" value="1 s"/>
+        <Constant name="VOLT_SCALE" dimension="voltage" value="1 V"/>
+        <Constant name="offset" dimension="voltage" value="0.010V"/>
+
+        <Dynamics>
+            <DerivedVariable name="V" dimension="none" value="(v - offset) / VOLT_SCALE"/>
+            <ConditionalDerivedVariable name="r" exposure="r" dimension="per_time">
+                <Case condition="V   .lt. ( -0.060 )" value="( 0 ) / TIME_SCALE"/>
+                <Case value="( 5 - (5 * (exp (-50 * (V - (-0.060)))))) / TIME_SCALE"/>
+            </ConditionalDerivedVariable>
+        </Dynamics>
+
+    </ComponentType>
+
+</neuroml>

--- a/tests/neuroml2/GranuleCell/Gran_CaPool_98.nml
+++ b/tests/neuroml2/GranuleCell/Gran_CaPool_98.nml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="ISO-8859-1"?>
+<neuroml xmlns="http://www.neuroml.org/schema/neuroml2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.neuroml.org/schema/neuroml2 https://raw.github.com/NeuroML/NeuroML2/development/Schemas/NeuroML2/NeuroML_v2beta4.xsd" id="Gran_CaPool_98">
+
+    <notes>A channel from Maex, R and De Schutter, E. Synchronization of Golgi and Granule Cell Firing in a 
+	Detailed Network Model of the Cerebellar Granule Cell Layer</notes>
+
+    <decayingPoolConcentrationModel id="Gran_CaPool_98" restingConc="7.55e-5mM" decayConstant="1e-2s" ion="ca" shellThickness="8.4e-8m"/>
+
+</neuroml>

--- a/tests/neuroml2/GranuleCell/Gran_H_98.channel.nml
+++ b/tests/neuroml2/GranuleCell/Gran_H_98.channel.nml
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="ISO-8859-1"?>
+<neuroml xmlns="http://www.neuroml.org/schema/neuroml2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.neuroml.org/schema/neuroml2 https://raw.github.com/NeuroML/NeuroML2/development/Schemas/NeuroML2/NeuroML_v2beta4.xsd" id="Gran_H_98">
+
+    <notes>A channel from Maex, R and De Schutter, E. Synchronization of Golgi and Granule Cell Firing in a 
+    Detailed Network Model of the Cerebellar Granule Cell Layer</notes>
+
+    <ionChannel id="Gran_H_98" conductance="10pS" type="ionChannelHH" species="h">
+
+        <notes>Anomalous inward rectifying H conductance</notes>
+                
+        <annotation>
+            <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+                <rdf:Description rdf:about="Gran_H_98">
+                    
+                    <bqmodel:isDescribedBy xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+                        <rdf:Bag>
+                            <rdf:li>Maex, R and De Schutter, E. 
+           Synchronization of Golgi and Granule Cell Firing in a Detailed Network Model of the 
+           cerebellar Granule Cell Layer. J Neurophysiol, Nov 1998; 80: 2521 - 2537</rdf:li>
+                            <rdf:li rdf:resource="http://www.ncbi.nlm.nih.gov/pubmed/21829333"/>
+                        </rdf:Bag>
+                    </bqmodel:isDescribedBy>
+
+                </rdf:Description>
+            </rdf:RDF>
+        </annotation>
+
+        <gate id="n" type="gateHHrates" instances="1">
+            <q10Settings type="q10ExpTemp" q10Factor="3" experimentalTemp="17.350264793 degC"/>
+            <!--Note: offset from ChannelML file incorporated into the midpoint of rates!!-->
+            <forwardRate type="HHExpRate" rate="0.8per_s" scale="-0.01100110011V" midpoint="-0.065V"/>
+            <reverseRate type="HHExpRate" rate="0.8per_s" scale="0.01100110011V" midpoint="-0.065V"/>
+        </gate>
+                            
+    </ionChannel>
+
+</neuroml>

--- a/tests/neuroml2/GranuleCell/Gran_KA_98.channel.nml
+++ b/tests/neuroml2/GranuleCell/Gran_KA_98.channel.nml
@@ -1,0 +1,76 @@
+<?xml version="1.0" encoding="ISO-8859-1"?>
+<neuroml xmlns="http://www.neuroml.org/schema/neuroml2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.neuroml.org/schema/neuroml2 https://raw.github.com/NeuroML/NeuroML2/development/Schemas/NeuroML2/NeuroML_v2beta4.xsd" id="Gran_KA_98">
+
+    <notes>A channel from Maex, R and De Schutter, E. Synchronization of Golgi and Granule Cell Firing in a 
+    Detailed Network Model of the Cerebellar Granule Cell Layer</notes>
+
+    <ionChannel id="Gran_KA_98" conductance="10pS" type="ionChannelHH" species="k">
+
+        <notes>A-type K channel, with rate equations expressed in tau and inf form</notes>
+                
+        <annotation>
+            <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+                <rdf:Description rdf:about="Gran_KA_98">
+                    
+                    <bqmodel:isDescribedBy xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+                        <rdf:Bag>
+                            <rdf:li>Maex, R and De Schutter, E. 
+           Synchronization of Golgi and Granule Cell Firing in a Detailed Network Model of the 
+           cerebellar Granule Cell Layer. J Neurophysiol, Nov 1998; 80: 2521 - 2537</rdf:li>
+                            <rdf:li rdf:resource="http://www.ncbi.nlm.nih.gov/pubmed/9819260"/>
+                        </rdf:Bag>
+                    </bqmodel:isDescribedBy>
+
+                
+                    <bqbiol:isVersionOf xmlns:bqbiol="http://biomodels.net/biology-qualifiers/">
+                        <rdf:Bag>
+                            <rdf:li>K channels</rdf:li>
+                            <rdf:li rdf:resource="http://senselab.med.yale.edu/neurondb/channelGene2.aspx#table3"/>
+                        </rdf:Bag>
+                    </bqbiol:isVersionOf>
+
+                </rdf:Description>
+            </rdf:RDF>
+        </annotation>
+
+        <gate id="m" type="gateHHtauInf" instances="3">
+            <q10Settings type="q10ExpTemp" q10Factor="1" experimentalTemp="17.350264793 degC"/>
+            <!--Note: offset from ChannelML file incorporated into the midpoint of rates!!-->
+            <timeCourse type="Gran_KA_98_m_tau_tau"/>
+            <steadyState type="HHSigmoidVariable" rate="1" scale="0.0198V" midpoint="-0.036699999999999997V"/>
+        </gate>
+
+        <gate id="h" type="gateHHtauInf" instances="1">
+            <q10Settings type="q10ExpTemp" q10Factor="1" experimentalTemp="17.350264793 degC"/>
+            <!--Note: offset from ChannelML file incorporated into the midpoint of rates!!-->
+            <timeCourse type="Gran_KA_98_h_tau_tau"/>
+            <steadyState type="HHSigmoidVariable" rate="1" scale="-0.0084V" midpoint="-0.0688V"/>
+        </gate>
+                            
+    </ionChannel>
+
+    <ComponentType name="Gran_KA_98_m_tau_tau" extends="baseVoltageDepTime">
+        <Constant name="TIME_SCALE" dimension="time" value="1 s"/>
+        <Constant name="VOLT_SCALE" dimension="voltage" value="1 V"/>
+        <Constant name="offset" dimension="voltage" value="0.010V"/>
+
+        <Dynamics>
+            <DerivedVariable name="V" dimension="none" value="(v - offset) / VOLT_SCALE"/>
+            <DerivedVariable name="t" exposure="t" dimension="time" value="(0.410e-3 * ((exp (( ((V) + 0.0435) / (-0.0428))))) + 0.167e-3) * TIME_SCALE"/>
+        </Dynamics>
+
+    </ComponentType>
+
+    <ComponentType name="Gran_KA_98_h_tau_tau" extends="baseVoltageDepTime">
+        <Constant name="TIME_SCALE" dimension="time" value="1 s"/>
+        <Constant name="VOLT_SCALE" dimension="voltage" value="1 V"/>
+        <Constant name="offset" dimension="voltage" value="0.010V"/>
+
+        <Dynamics>
+            <DerivedVariable name="V" dimension="none" value="(v - offset) / VOLT_SCALE"/>
+            <DerivedVariable name="t" exposure="t" dimension="time" value="(0.001 * (10.8 + (30 * V) + (1 / (57.9 * (exp (V * 127)) + (134e-6 * (exp (V * (-59)))))))) * TIME_SCALE"/>
+        </Dynamics>
+
+    </ComponentType>
+
+</neuroml>

--- a/tests/neuroml2/GranuleCell/Gran_KCa_98.channel.nml
+++ b/tests/neuroml2/GranuleCell/Gran_KCa_98.channel.nml
@@ -1,0 +1,73 @@
+<?xml version="1.0" encoding="ISO-8859-1"?>
+<neuroml xmlns="http://www.neuroml.org/schema/neuroml2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.neuroml.org/schema/neuroml2 https://raw.github.com/NeuroML/NeuroML2/development/Schemas/NeuroML2/NeuroML_v2beta4.xsd" id="Gran_KCa_98">
+
+    <notes>A channel from Maex, R and De Schutter, E. Synchronization of Golgi and Granule Cell Firing in a 
+    Detailed Network Model of the Cerebellar Granule Cell Layer</notes>
+
+    <ionChannel id="Gran_KCa_98" conductance="10pS" type="ionChannelHH" species="k">
+
+        <notes>Calcium dependent K+ channel</notes>
+                
+        <annotation>
+            <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+                <rdf:Description rdf:about="Gran_KCa_98">
+                    
+                    <bqmodel:isDescribedBy xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+                        <rdf:Bag>
+                            <rdf:li>Maex, R and De Schutter, E. 
+           Synchronization of Golgi and Granule Cell Firing in a Detailed Network Model of the 
+           cerebellar Granule Cell Layer. J Neurophysiol, Nov 1998; 80: 2521 - 2537</rdf:li>
+                            <rdf:li rdf:resource="http://www.ncbi.nlm.nih.gov/pubmed/9819260"/>
+                        </rdf:Bag>
+                    </bqmodel:isDescribedBy>
+
+                
+                    <bqbiol:isVersionOf xmlns:bqbiol="http://biomodels.net/biology-qualifiers/">
+                        <rdf:Bag>
+                            <rdf:li>K channels</rdf:li>
+                            <rdf:li rdf:resource="http://senselab.med.yale.edu/neurondb/channelGene2.aspx#table3"/>
+                        </rdf:Bag>
+                    </bqbiol:isVersionOf>
+
+                </rdf:Description>
+            </rdf:RDF>
+        </annotation>
+
+        <gate id="m" type="gateHHrates" instances="1">
+            <q10Settings type="q10ExpTemp" q10Factor="3" experimentalTemp="17.350264793 degC"/>
+            <!--Note: offset from ChannelML file incorporated into the midpoint of rates!!-->
+            <forwardRate type="Gran_KCa_98_m_alpha_rate"/>
+            <reverseRate type="Gran_KCa_98_m_beta_rate"/>
+        </gate>
+                            
+    </ionChannel>
+
+    <ComponentType name="Gran_KCa_98_m_alpha_rate" extends="baseVoltageConcDepRate">
+        <Constant name="TIME_SCALE" dimension="time" value="1 s"/>
+        <Constant name="VOLT_SCALE" dimension="voltage" value="1 V"/>
+        <Constant name="CONC_SCALE" dimension="concentration" value="1 mM"/>
+        <Constant name="offset" dimension="voltage" value="0.010V"/>
+
+        <Dynamics>
+            <DerivedVariable name="V" dimension="none" value="(v - offset) / VOLT_SCALE"/>
+            <DerivedVariable name="ca_conc" dimension="none" value="caConc / CONC_SCALE"/>
+            <DerivedVariable name="r" exposure="r" dimension="per_time" value="(2500/(1 + ( (1.5e-3 *(exp (-85*V))) / ca_conc))) / TIME_SCALE"/>
+        </Dynamics>
+
+    </ComponentType>
+
+    <ComponentType name="Gran_KCa_98_m_beta_rate" extends="baseVoltageConcDepRate">
+        <Constant name="TIME_SCALE" dimension="time" value="1 s"/>
+        <Constant name="VOLT_SCALE" dimension="voltage" value="1 V"/>
+        <Constant name="CONC_SCALE" dimension="concentration" value="1 mM"/>
+        <Constant name="offset" dimension="voltage" value="0.010V"/>
+
+        <Dynamics>
+            <DerivedVariable name="V" dimension="none" value="(v - offset) / VOLT_SCALE"/>
+            <DerivedVariable name="ca_conc" dimension="none" value="caConc / CONC_SCALE"/>
+            <DerivedVariable name="r" exposure="r" dimension="per_time" value="(1500/(1 + (ca_conc / (1.5e-4 * (exp (-77*V)))))) / TIME_SCALE"/>
+        </Dynamics>
+
+    </ComponentType>
+
+</neuroml>

--- a/tests/neuroml2/GranuleCell/Gran_KDr_98.channel.nml
+++ b/tests/neuroml2/GranuleCell/Gran_KDr_98.channel.nml
@@ -1,0 +1,103 @@
+<?xml version="1.0" encoding="ISO-8859-1"?>
+<neuroml xmlns="http://www.neuroml.org/schema/neuroml2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.neuroml.org/schema/neuroml2 https://raw.github.com/NeuroML/NeuroML2/development/Schemas/NeuroML2/NeuroML_v2beta4.xsd" id="Gran_KDr_98">
+
+    <notes>A channel from Maex, R and De Schutter, E. Synchronization of Golgi and Granule Cell Firing in a 
+    Detailed Network Model of the Cerebellar Granule Cell Layer</notes>
+
+    <ionChannel id="Gran_KDr_98" conductance="10pS" type="ionChannelHH" species="k">
+
+        <notes>Delayed rectifyer K channel</notes>
+                
+        <annotation>
+            <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+                <rdf:Description rdf:about="Gran_KDr_98">
+                    
+                    <bqmodel:isDescribedBy xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+                        <rdf:Bag>
+                            <rdf:li>Maex, R and De Schutter, E. 
+           Synchronization of Golgi and Granule Cell Firing in a Detailed Network Model of the 
+           cerebellar Granule Cell Layer. J Neurophysiol, Nov 1998; 80: 2521 - 2537</rdf:li>
+                            <rdf:li rdf:resource="http://www.ncbi.nlm.nih.gov/pubmed/9819260"/>
+                        </rdf:Bag>
+                    </bqmodel:isDescribedBy>
+
+                
+                    <bqbiol:isVersionOf xmlns:bqbiol="http://biomodels.net/biology-qualifiers/">
+                        <rdf:Bag>
+                            <rdf:li>K channels</rdf:li>
+                            <rdf:li rdf:resource="http://senselab.med.yale.edu/neurondb/channelGene2.aspx#table3"/>
+                        </rdf:Bag>
+                    </bqbiol:isVersionOf>
+
+                </rdf:Description>
+            </rdf:RDF>
+        </annotation>
+
+        <gate id="m" type="gateHHrates" instances="4">
+            <q10Settings type="q10ExpTemp" q10Factor="3" experimentalTemp="17.350264793 degC"/>
+            <!--Note: offset from ChannelML file incorporated into the midpoint of rates!!-->
+            <forwardRate type="Gran_KDr_98_m_alpha_rate"/>
+            <reverseRate type="Gran_KDr_98_m_beta_rate"/>
+        </gate>
+
+        <gate id="h" type="gateHHrates" instances="1">
+            <q10Settings type="q10ExpTemp" q10Factor="3" experimentalTemp="17.350264793 degC"/>
+            <!--Note: offset from ChannelML file incorporated into the midpoint of rates!!-->
+            <forwardRate type="Gran_KDr_98_h_alpha_rate"/>
+            <reverseRate type="Gran_KDr_98_h_beta_rate"/>
+        </gate>
+                            
+    </ionChannel>
+
+    <ComponentType name="Gran_KDr_98_m_alpha_rate" extends="baseVoltageDepRate">
+        <Constant name="TIME_SCALE" dimension="time" value="1 s"/>
+        <Constant name="VOLT_SCALE" dimension="voltage" value="1 V"/>
+        <Constant name="offset" dimension="voltage" value="0.010V"/>
+
+        <Dynamics>
+            <DerivedVariable name="V" dimension="none" value="(v - offset) / VOLT_SCALE"/>
+            <DerivedVariable name="r" exposure="r" dimension="per_time" value="(170 * ((exp (73 *(V - (-0.038)))))) / TIME_SCALE"/>
+        </Dynamics>
+
+    </ComponentType>
+
+    <ComponentType name="Gran_KDr_98_m_beta_rate" extends="baseVoltageDepRate">
+        <Constant name="TIME_SCALE" dimension="time" value="1 s"/>
+        <Constant name="VOLT_SCALE" dimension="voltage" value="1 V"/>
+        <Constant name="offset" dimension="voltage" value="0.010V"/>
+
+        <Dynamics>
+            <DerivedVariable name="V" dimension="none" value="(v - offset) / VOLT_SCALE"/>
+            <DerivedVariable name="r" exposure="r" dimension="per_time" value="(170 * ((exp ((-18) *(V - (-0.038)))))) / TIME_SCALE"/>
+        </Dynamics>
+
+    </ComponentType>
+
+    <ComponentType name="Gran_KDr_98_h_alpha_rate" extends="baseVoltageDepRate">
+        <Constant name="TIME_SCALE" dimension="time" value="1 s"/>
+        <Constant name="VOLT_SCALE" dimension="voltage" value="1 V"/>
+        <Constant name="offset" dimension="voltage" value="0.010V"/>
+
+        <Dynamics>
+            <DerivedVariable name="V" dimension="none" value="(v - offset) / VOLT_SCALE"/>
+            <ConditionalDerivedVariable name="r" exposure="r" dimension="per_time">
+                <Case condition="V  .gt. ( -0.046 )" value="( 0.76 ) / TIME_SCALE"/>
+                <Case value="( 0.7 + 0.065*(exp (-80*(V - (-0.046))))) / TIME_SCALE"/>
+            </ConditionalDerivedVariable>
+        </Dynamics>
+
+    </ComponentType>
+
+    <ComponentType name="Gran_KDr_98_h_beta_rate" extends="baseVoltageDepRate">
+        <Constant name="TIME_SCALE" dimension="time" value="1 s"/>
+        <Constant name="VOLT_SCALE" dimension="voltage" value="1 V"/>
+        <Constant name="offset" dimension="voltage" value="0.010V"/>
+
+        <Dynamics>
+            <DerivedVariable name="V" dimension="none" value="(v - offset) / VOLT_SCALE"/>
+            <DerivedVariable name="r" exposure="r" dimension="per_time" value="(1.1/(1 + (exp (-80.7 * (V - (-0.044)))))) / TIME_SCALE"/>
+        </Dynamics>
+
+    </ComponentType>
+
+</neuroml>

--- a/tests/neuroml2/GranuleCell/Gran_NaF_98.channel.nml
+++ b/tests/neuroml2/GranuleCell/Gran_NaF_98.channel.nml
@@ -1,0 +1,94 @@
+<?xml version="1.0" encoding="ISO-8859-1"?>
+<neuroml xmlns="http://www.neuroml.org/schema/neuroml2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.neuroml.org/schema/neuroml2 https://raw.github.com/NeuroML/NeuroML2/development/Schemas/NeuroML2/NeuroML_v2beta4.xsd" id="Gran_NaF_98">
+
+    <notes>A channel from Maex, R and De Schutter, E. Synchronization of Golgi and Granule Cell Firing in a 
+    Detailed Network Model of the Cerebellar Granule Cell Layer</notes>
+
+    <ionChannel id="Gran_NaF_98" conductance="10pS" type="ionChannelHH" species="na">
+
+        <notes>Fast inactivating Na+ channel</notes>
+                
+        <annotation>
+            <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+                <rdf:Description rdf:about="Gran_NaF_98">
+                    
+                    <bqmodel:isDescribedBy xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+                        <rdf:Bag>
+                            <rdf:li>Maex, R and De Schutter, E. 
+           Synchronization of Golgi and Granule Cell Firing in a Detailed Network Model of the 
+           cerebellar Granule Cell Layer. J Neurophysiol, Nov 1998; 80: 2521 - 2537</rdf:li>
+                            <rdf:li rdf:resource="http://www.ncbi.nlm.nih.gov/pubmed/9819260"/>
+                        </rdf:Bag>
+                    </bqmodel:isDescribedBy>
+
+                
+                    <bqbiol:isVersionOf xmlns:bqbiol="http://biomodels.net/biology-qualifiers/">
+                        <rdf:Bag>
+                            <rdf:li>Na channels</rdf:li>
+                            <rdf:li rdf:resource="http://senselab.med.yale.edu/neurondb/channelGene2.aspx#table2"/>
+                        </rdf:Bag>
+                    </bqbiol:isVersionOf>
+
+                </rdf:Description>
+            </rdf:RDF>
+        </annotation>
+
+        <gate id="m" type="gateHHratesTau" instances="3">
+            <q10Settings type="q10ExpTemp" q10Factor="3" experimentalTemp="17.350264793 degC"/>
+            <!--Note: offset from ChannelML file incorporated into the midpoint of rates!!-->
+            <forwardRate type="HHExpRate" rate="1500per_s" scale="0.012345679V" midpoint="-0.028999999999999998V"/>
+            <reverseRate type="HHExpRate" rate="1500per_s" scale="-0.0151515V" midpoint="-0.028999999999999998V"/>
+            <timeCourse type="Gran_NaF_98_m_tau_tau"/>
+        </gate>
+
+        <gate id="h" type="gateHHratesTau" instances="1">
+            <q10Settings type="q10ExpTemp" q10Factor="3" experimentalTemp="17.350264793 degC"/>
+            <!--Note: offset from ChannelML file incorporated into the midpoint of rates!!-->
+            <forwardRate type="HHExpRate" rate="120per_s" scale="-0.01123596V" midpoint="-0.04V"/>
+            <reverseRate type="HHExpRate" rate="120per_s" scale="0.01123596V" midpoint="-0.04V"/>
+            <timeCourse type="Gran_NaF_98_h_tau_tau"/>
+        </gate>
+                            
+    </ionChannel>
+
+    <ComponentType name="Gran_NaF_98_m_tau_tau" extends="baseVoltageDepTime">
+        <Constant name="TIME_SCALE" dimension="time" value="1 s"/>
+        <Constant name="VOLT_SCALE" dimension="voltage" value="1 V"/>
+        <Constant name="offset" dimension="voltage" value="0.010V"/>
+        <Requirement name="alpha" dimension="per_time"/>
+        <Requirement name="beta" dimension="per_time"/>
+
+        <Dynamics>
+            <DerivedVariable name="V" dimension="none" value="(v - offset) / VOLT_SCALE"/>
+            <DerivedVariable name="ALPHA" dimension="none" value="alpha * TIME_SCALE"/>
+            <DerivedVariable name="BETA" dimension="none" value="beta * TIME_SCALE"/>
+            <ConditionalDerivedVariable name="t" exposure="t" dimension="time">
+                <Case condition="(ALPHA + BETA) .eq. 0" value="( 0 ) * TIME_SCALE"/>
+                <Case condition="1/(ALPHA + BETA)  .lt. ( 0.00005 )" value="( 0.00005 ) * TIME_SCALE"/>
+                <Case value="( 1/(ALPHA + BETA)) * TIME_SCALE"/>
+            </ConditionalDerivedVariable>
+        </Dynamics>
+
+    </ComponentType>
+
+    <ComponentType name="Gran_NaF_98_h_tau_tau" extends="baseVoltageDepTime">
+        <Constant name="TIME_SCALE" dimension="time" value="1 s"/>
+        <Constant name="VOLT_SCALE" dimension="voltage" value="1 V"/>
+        <Constant name="offset" dimension="voltage" value="0.010V"/>
+        <Requirement name="alpha" dimension="per_time"/>
+        <Requirement name="beta" dimension="per_time"/>
+
+        <Dynamics>
+            <DerivedVariable name="V" dimension="none" value="(v - offset) / VOLT_SCALE"/>
+            <DerivedVariable name="ALPHA" dimension="none" value="alpha * TIME_SCALE"/>
+            <DerivedVariable name="BETA" dimension="none" value="beta * TIME_SCALE"/>
+            <ConditionalDerivedVariable name="t" exposure="t" dimension="time">
+                <Case condition="(ALPHA + BETA) .eq. 0" value="( 0 ) * TIME_SCALE"/>
+                <Case condition="1/(ALPHA + BETA)  .lt. ( 0.000225 )" value="( 0.000225 ) * TIME_SCALE"/>
+                <Case value="( 1/(ALPHA + BETA)) * TIME_SCALE"/>
+            </ConditionalDerivedVariable>
+        </Dynamics>
+
+    </ComponentType>
+
+</neuroml>

--- a/tests/neuroml2/GranuleCell/GranuleCell.net.nml
+++ b/tests/neuroml2/GranuleCell/GranuleCell.net.nml
@@ -1,0 +1,57 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<neuroml xmlns="http://www.neuroml.org/schema/neuroml2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.neuroml.org/schema/neuroml2  https://raw.github.com/NeuroML/NeuroML2/development/Schemas/NeuroML2/NeuroML_v2beta3.xsd" id="network_GranuleCell">
+
+    <notes>
+
+Network structure (NeuroML 2beta3) for project: GranuleCell saved with neuroConstruct v1.7.1 on: 17:47:34, 16-Apr-14
+
+Cell Group: Gran contains 1 cells
+
+
+
+    </notes>
+
+
+    <include href="Gran_CaHVA_98.channel.nml"/>
+    <include href="Gran_CaPool_98.nml"/>
+    <include href="Gran_H_98.channel.nml"/>
+    <include href="Gran_KA_98.channel.nml"/>
+    <include href="Gran_KCa_98.channel.nml"/>
+    <include href="Gran_KDr_98.channel.nml"/>
+    <include href="Gran_NaF_98.channel.nml"/>
+    <include href="GranPassiveCond.channel.nml"/>
+    <include href="Granule_98.cell.nml"/>
+
+    <pulseGenerator id="Gran_10pA" delay="100.0ms" duration="500.0ms" amplitude="1.0E-5uA"/>
+
+    
+    <network id="network_GranuleCell" type="networkWithTemperature" temperature="32.0 degC">
+        <property tag="recommended_dt_ms" value="0.025"/>
+        <property tag="recommended_duration_ms" value="700.0"/>
+        
+
+        <population id="Gran" component="Granule_98" type="populationList" size="1">
+           <annotation>
+                <property tag="color" value="0.69921875 0.5703125 0.96484375"/>
+            </annotation>
+            <instance id="0">
+                <location x="64.65821" y="50.0" z="0.0"/>
+            </instance>
+        </population>
+
+
+
+            <!--There are no synaptic connections present in the network-->
+
+
+        <inputList id="Gran_10pA" component="Gran_10pA" population="Gran">
+            <input id="0" target="../Gran/0/Granule_98" destination="synapses"/>
+        </inputList>
+
+
+
+
+
+    </network>
+
+</neuroml>

--- a/tests/neuroml2/GranuleCell/Granule_98.cell.nml
+++ b/tests/neuroml2/GranuleCell/Granule_98.cell.nml
@@ -1,0 +1,92 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<neuroml xmlns="http://www.neuroml.org/schema/neuroml2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.neuroml.org/schema/neuroml2  https://raw.githubusercontent.com/NeuroML/NeuroML2/development/Schemas/NeuroML2/NeuroML_v2beta4.xsd" id="Granule_98">
+
+    <include href="Gran_CaHVA_98.channel.nml"/>
+
+    <include href="Gran_CaPool_98.nml"/>
+
+    <include href="Gran_H_98.channel.nml"/>
+
+    <include href="Gran_KA_98.channel.nml"/>
+
+    <include href="Gran_KCa_98.channel.nml"/>
+
+    <include href="Gran_KDr_98.channel.nml"/>
+
+    <include href="Gran_NaF_98.channel.nml"/>
+
+    <include href="GranPassiveCond.channel.nml"/>
+
+    <cell id="Granule_98" neuroLexId="nifext_128">
+
+        <notes>An implementation using ChannelML of the Granule cell mode from Maex, R and De Schutter, E. Synchronization of Golgi and Granule Cell Firing in a Detailed Network Model of the Cerebellar Granule Cell Layer, 1998</notes>
+
+        <morphology id="morphology_Granule_98">
+
+            <segment id="0" name="Soma">
+                <proximal x="0.0" y="0.0" z="0.0" diameter="10.0"/>
+                <distal x="0.0" y="0.0" z="0.0" diameter="10.0"/>
+            </segment>
+
+            <segmentGroup id="Soma" neuroLexId="sao864921383">    <!--
+                This group contains an unbranched set of segments, and all of the segmentGroups marked with
+                neuroLexId = sao864921383 form a non-overlapping set of all of the segments. 
+                These segmentGroups correspond to the 'cables' of NeuroML v1.8.1. -->
+
+                <member segment="0"/>
+            </segmentGroup>
+
+            <segmentGroup id="all">
+                <include segmentGroup="Soma"/>
+            </segmentGroup>
+
+            <segmentGroup id="soma_group" neuroLexId="GO:0043025">    <!--Soma group-->
+
+                <include segmentGroup="Soma"/>
+            </segmentGroup>
+
+            
+        </morphology>
+
+            <!--Adding the biophysical parameters-->
+
+        <biophysicalProperties id="biophys">
+
+            <membraneProperties>
+                
+                <channelDensity condDensity="0.9084216 mS_per_cm2" id="Gran_CaHVA_98_all" ionChannel="Gran_CaHVA_98" ion="ca" erev="80.0 mV"/>
+                
+                <channelDensity condDensity="0.03090506 mS_per_cm2" id="Gran_H_98_all" ionChannel="Gran_H_98" ion="h" erev="-42.0 mV"/>
+                
+                <channelDensity condDensity="1.14567 mS_per_cm2" id="Gran_KA_98_all" ionChannel="Gran_KA_98" ion="k" erev="-90.0 mV"/>
+                
+                <channelDensity condDensity="17.9811 mS_per_cm2" id="Gran_KCa_98_all" ionChannel="Gran_KCa_98" ion="k" erev="-90.0 mV"/>
+                
+                <channelDensity condDensity="8.89691 mS_per_cm2" id="Gran_KDr_98_all" ionChannel="Gran_KDr_98" ion="k" erev="-90.0 mV"/>
+                
+                <channelDensity condDensity="55.7227 mS_per_cm2" id="Gran_NaF_98_all" ionChannel="Gran_NaF_98" ion="na" erev="55.0 mV"/>
+                
+                <channelDensity condDensity="0.0330033 mS_per_cm2" id="GranPassiveCond_all" ionChannel="GranPassiveCond" erev="-65.0 mV" ion="non_specific"/>
+                
+
+                <spikeThresh value="0.0 mV"/>
+
+                <specificCapacitance value="1.0 uF_per_cm2"/>
+
+                <initMembPotential value="-65.0 mV"/>
+
+            </membraneProperties>
+
+            <intracellularProperties>
+
+                <species id="ca" ion="ca" concentrationModel="Gran_CaPool_98" initialConcentration="7.55E-11 mol_per_cm3" initialExtConcentration="2.4E-6 mol_per_cm3"/>
+
+                <resistivity value="0.1 kohm_cm"/>
+
+            </intracellularProperties>
+
+        </biophysicalProperties>
+
+    </cell>
+    
+</neuroml>

--- a/tests/neuroml2/GranuleCell/README--GENERATED-FILES
+++ b/tests/neuroml2/GranuleCell/README--GENERATED-FILES
@@ -1,0 +1,2 @@
+These files are not the source files for the model, they have been generated from the source of the model in the neuroConstruct directory.
+These have been added to provide examples of valid NeuroML files for testing applications & the OSB website and may be removed at any time.

--- a/tests/neuroml2/GranuleCell/analyse.sh
+++ b/tests/neuroml2/GranuleCell/analyse.sh
@@ -1,0 +1,4 @@
+# Gran_H_98.channel.nml        missing 
+# GranPassiveCond.channel.nml  missing as it's passive
+# Gran_KDr_98.channel.nml      missing
+pynml-channelanalysis -temperature 32 -html -md Gran_CaHVA_98.channel.nml  Gran_KA_98.channel.nml  Gran_KCa_98.channel.nml  Gran_NaF_98.channel.nml

--- a/tests/neuroml2/GranuleCell/channel_summary/README.md
+++ b/tests/neuroml2/GranuleCell/channel_summary/README.md
@@ -1,0 +1,68 @@
+Channel information
+===================
+    
+<p style="font-family:arial">Channel information at: T = 32.0 degC, E_rev = 0 mV, [Ca2+] = 5e-05 mM</p>
+
+<table>
+    <tr>
+<td width="120px">
+            <sup><b>Gran_NaF_98</b><br/>
+            <a href="../Gran_NaF_98.channel.nml">Gran_NaF_98.channel.nml</a><br/>
+            <b>Ion: na</b><br/>
+            <i>g = gmax * m<sup>3</sup> * h </i><br/>
+            Fast inactivating Na+ channel</sup>
+</td>
+<td>
+<a href="Gran_NaF_98.inf.png"><img alt="Gran_NaF_98 steady state" src="Gran_NaF_98.inf.png" height="220"/></a>
+</td>
+<td>
+<a href="Gran_NaF_98.tau.png"><img alt="Gran_NaF_98 time course" src="Gran_NaF_98.tau.png" height="220"/></a>
+</td>
+</tr>
+    <tr>
+<td width="120px">
+            <sup><b>Gran_KA_98</b><br/>
+            <a href="../Gran_KA_98.channel.nml">Gran_KA_98.channel.nml</a><br/>
+            <b>Ion: k</b><br/>
+            <i>g = gmax * m<sup>3</sup> * h </i><br/>
+            A-type K channel, with rate equations expressed in tau and inf form</sup>
+</td>
+<td>
+<a href="Gran_KA_98.inf.png"><img alt="Gran_KA_98 steady state" src="Gran_KA_98.inf.png" height="220"/></a>
+</td>
+<td>
+<a href="Gran_KA_98.tau.png"><img alt="Gran_KA_98 time course" src="Gran_KA_98.tau.png" height="220"/></a>
+</td>
+</tr>
+    <tr>
+<td width="120px">
+            <sup><b>Gran_KCa_98</b><br/>
+            <a href="../Gran_KCa_98.channel.nml">Gran_KCa_98.channel.nml</a><br/>
+            <b>Ion: k</b><br/>
+            <i>g = gmax * m </i><br/>
+            Calcium dependent K+ channel</sup>
+</td>
+<td>
+<a href="Gran_KCa_98.inf.png"><img alt="Gran_KCa_98 steady state" src="Gran_KCa_98.inf.png" height="220"/></a>
+</td>
+<td>
+<a href="Gran_KCa_98.tau.png"><img alt="Gran_KCa_98 time course" src="Gran_KCa_98.tau.png" height="220"/></a>
+</td>
+</tr>
+    <tr>
+<td width="120px">
+            <sup><b>Gran_CaHVA_98</b><br/>
+            <a href="../Gran_CaHVA_98.channel.nml">Gran_CaHVA_98.channel.nml</a><br/>
+            <b>Ion: ca</b><br/>
+            <i>g = gmax * m<sup>2</sup> * h </i><br/>
+            A High Voltage Activated Ca2+ channel</sup>
+</td>
+<td>
+<a href="Gran_CaHVA_98.inf.png"><img alt="Gran_CaHVA_98 steady state" src="Gran_CaHVA_98.inf.png" height="220"/></a>
+</td>
+<td>
+<a href="Gran_CaHVA_98.tau.png"><img alt="Gran_CaHVA_98 time course" src="Gran_CaHVA_98.tau.png" height="220"/></a>
+</td>
+</tr>
+</table>
+

--- a/tests/neuroml2/GranuleCell/generate_if.py
+++ b/tests/neuroml2/GranuleCell/generate_if.py
@@ -1,0 +1,50 @@
+
+from pyneuroml.analysis import generate_current_vs_frequency_curve
+
+simulator = 'jNeuroML'
+
+res_1_jnml = generate_current_vs_frequency_curve(nml2_file =          'Granule_98.cell.nml', 
+                                                 cell_id =            'Granule_98', 
+                                                 start_amp_nA =       0, 
+                                                 end_amp_nA =         0.08, 
+                                                 step_nA =            0.005, 
+                                                 analysis_duration =  1500, 
+                                                 analysis_delay =     50,
+                                                 dt =                 0.01,
+                                                 plot_voltage_traces= False,
+                                                 temperature=         "32degC",
+                                                 simulator =          simulator,
+                                                 plot_if =            False)
+
+simulator = 'jNeuroML_NEURON'
+
+res_1_jnrn = generate_current_vs_frequency_curve(nml2_file =          'Granule_98.cell.nml', 
+                                                 cell_id =            'Granule_98', 
+                                                 start_amp_nA =       0, 
+                                                 end_amp_nA =         0.08, 
+                                                 step_nA =            0.005, 
+                                                 analysis_duration =  1500, 
+                                                 analysis_delay =     50,
+                                                 dt =                 0.01,
+                                                 plot_voltage_traces= False,
+                                                 temperature=         "32degC",
+                                                 simulator =          simulator,
+                                                 plot_if =            False)
+                                                 
+                                                 
+
+simulator = 'jNeuroML_NEURON'
+
+
+from matplotlib import pyplot as plt
+
+plt.xlabel('Input current (nA)')
+plt.ylabel('Firing frequency (Hz)')
+plt.grid('on')
+
+plt.plot(res_1_jnml.keys(), res_1_jnml.values(), 'o', label="jNeuroML")
+plt.plot(res_1_jnrn.keys(), res_1_jnrn.values(), 'o', label="jNeuroML_NEURON")
+
+plt.legend(loc='upper center', bbox_to_anchor=(0.5, -0.05), fancybox=True, shadow=True, ncol=3)
+
+plt.show()

--- a/tests/neuroml2/GranuleCell/iv_Granule_98.net.nml
+++ b/tests/neuroml2/GranuleCell/iv_Granule_98.net.nml
@@ -1,0 +1,75 @@
+<neuroml xmlns="http://www.neuroml.org/schema/neuroml2"  xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.neuroml.org/schema/neuroml2 https://raw.github.com/NeuroML/NeuroML2/development/Schemas/NeuroML2/NeuroML_v2.3.1.xsd" id="network_of_Granule_98">
+    <include href="Granule_98.cell.nml"/>
+    <pulseGenerator id="input_0nA" delay="0ms" duration="1550ms" amplitude="0nA"/>
+    <pulseGenerator id="input_0_005nA" delay="0ms" duration="1550ms" amplitude="0.005nA"/>
+    <pulseGenerator id="input_0_01nA" delay="0ms" duration="1550ms" amplitude="0.01nA"/>
+    <pulseGenerator id="input_0_015nA" delay="0ms" duration="1550ms" amplitude="0.015nA"/>
+    <pulseGenerator id="input_0_02nA" delay="0ms" duration="1550ms" amplitude="0.02nA"/>
+    <pulseGenerator id="input_0_025nA" delay="0ms" duration="1550ms" amplitude="0.025nA"/>
+    <pulseGenerator id="input_0_030000000000000002nA" delay="0ms" duration="1550ms" amplitude="0.030000000000000002nA"/>
+    <pulseGenerator id="input_0_035nA" delay="0ms" duration="1550ms" amplitude="0.035nA"/>
+    <pulseGenerator id="input_0_04nA" delay="0ms" duration="1550ms" amplitude="0.04nA"/>
+    <pulseGenerator id="input_0_045nA" delay="0ms" duration="1550ms" amplitude="0.045nA"/>
+    <pulseGenerator id="input_0_049999999999999996nA" delay="0ms" duration="1550ms" amplitude="0.049999999999999996nA"/>
+    <pulseGenerator id="input_0_05499999999999999nA" delay="0ms" duration="1550ms" amplitude="0.05499999999999999nA"/>
+    <pulseGenerator id="input_0_05999999999999999nA" delay="0ms" duration="1550ms" amplitude="0.05999999999999999nA"/>
+    <pulseGenerator id="input_0_06499999999999999nA" delay="0ms" duration="1550ms" amplitude="0.06499999999999999nA"/>
+    <pulseGenerator id="input_0_06999999999999999nA" delay="0ms" duration="1550ms" amplitude="0.06999999999999999nA"/>
+    <pulseGenerator id="input_0_075nA" delay="0ms" duration="1550ms" amplitude="0.075nA"/>
+    <pulseGenerator id="input_0_08nA" delay="0ms" duration="1550ms" amplitude="0.08nA"/>
+    <network id="network_of_Granule_98" type="networkWithTemperature" temperature="6.3degC">
+    <!-- <network id="network_of_Granule_98" type="networkWithTemperature" temperature="32degC"> -->
+        <population id="population_of_Granule_98" component="Granule_98" size="17"/>
+        <inputList id="input_0nA" population="population_of_Granule_98" component="input_0nA">
+            <input id="0" target="../population_of_Granule_98[0]" destination="synapses"/>
+        </inputList>
+        <inputList id="input_0_005nA" population="population_of_Granule_98" component="input_0_005nA">
+            <input id="0" target="../population_of_Granule_98[1]" destination="synapses"/>
+        </inputList>
+        <inputList id="input_0_01nA" population="population_of_Granule_98" component="input_0_01nA">
+            <input id="0" target="../population_of_Granule_98[2]" destination="synapses"/>
+        </inputList>
+        <inputList id="input_0_015nA" population="population_of_Granule_98" component="input_0_015nA">
+            <input id="0" target="../population_of_Granule_98[3]" destination="synapses"/>
+        </inputList>
+        <inputList id="input_0_02nA" population="population_of_Granule_98" component="input_0_02nA">
+            <input id="0" target="../population_of_Granule_98[4]" destination="synapses"/>
+        </inputList>
+        <inputList id="input_0_025nA" population="population_of_Granule_98" component="input_0_025nA">
+            <input id="0" target="../population_of_Granule_98[5]" destination="synapses"/>
+        </inputList>
+        <inputList id="input_0_030000000000000002nA" population="population_of_Granule_98" component="input_0_030000000000000002nA">
+            <input id="0" target="../population_of_Granule_98[6]" destination="synapses"/>
+        </inputList>
+        <inputList id="input_0_035nA" population="population_of_Granule_98" component="input_0_035nA">
+            <input id="0" target="../population_of_Granule_98[7]" destination="synapses"/>
+        </inputList>
+        <inputList id="input_0_04nA" population="population_of_Granule_98" component="input_0_04nA">
+            <input id="0" target="../population_of_Granule_98[8]" destination="synapses"/>
+        </inputList>
+        <inputList id="input_0_045nA" population="population_of_Granule_98" component="input_0_045nA">
+            <input id="0" target="../population_of_Granule_98[9]" destination="synapses"/>
+        </inputList>
+        <inputList id="input_0_049999999999999996nA" population="population_of_Granule_98" component="input_0_049999999999999996nA">
+            <input id="0" target="../population_of_Granule_98[10]" destination="synapses"/>
+        </inputList>
+        <inputList id="input_0_05499999999999999nA" population="population_of_Granule_98" component="input_0_05499999999999999nA">
+            <input id="0" target="../population_of_Granule_98[11]" destination="synapses"/>
+        </inputList>
+        <inputList id="input_0_05999999999999999nA" population="population_of_Granule_98" component="input_0_05999999999999999nA">
+            <input id="0" target="../population_of_Granule_98[12]" destination="synapses"/>
+        </inputList>
+        <inputList id="input_0_06499999999999999nA" population="population_of_Granule_98" component="input_0_06499999999999999nA">
+            <input id="0" target="../population_of_Granule_98[13]" destination="synapses"/>
+        </inputList>
+        <inputList id="input_0_06999999999999999nA" population="population_of_Granule_98" component="input_0_06999999999999999nA">
+            <input id="0" target="../population_of_Granule_98[14]" destination="synapses"/>
+        </inputList>
+        <inputList id="input_0_075nA" population="population_of_Granule_98" component="input_0_075nA">
+            <input id="0" target="../population_of_Granule_98[15]" destination="synapses"/>
+        </inputList>
+        <inputList id="input_0_08nA" population="population_of_Granule_98" component="input_0_08nA">
+            <input id="0" target="../population_of_Granule_98[16]" destination="synapses"/>
+        </inputList>
+    </network>
+</neuroml>

--- a/tests/neuroml2/test_granule98.py
+++ b/tests/neuroml2/test_granule98.py
@@ -61,7 +61,7 @@ def dump_gate_tables(channel, do_plot=False):
 
 def test_granule98():
     modeldir = os.path.join(os.path.dirname(__file__), 'GranuleCell')
-    do_plot = True
+    do_plot = False
     reader = NML2Reader(verbose=True)
     filename = os.path.join(modeldir, "GranuleCell.net.nml")
     reader.read(filename)

--- a/tests/neuroml2/test_granule98.py
+++ b/tests/neuroml2/test_granule98.py
@@ -1,0 +1,152 @@
+# test_granule98.py ---
+#
+# Filename: test_granule98.py
+# Description:
+# Author: Subhasis Ray
+# Created: Mon Apr  8 21:41:22 2024 (+0530)
+#           By: Subhasis Ray
+#
+
+# Code:
+"""Test code for the Granule cell model
+
+"""
+import os
+import sys
+import numpy as np
+import matplotlib.pyplot as plt
+import pytest
+
+import logging
+
+
+LOGLEVEL = os.environ.get("LOGLEVEL", "INFO")
+logging.basicConfig(level=LOGLEVEL)
+
+
+import moose
+from moose.neuroml2 import NML2Reader
+
+
+def dump_gate_tables(channel, do_plot=False):
+    if do_plot:
+        fig, axes = plt.subplots(nrows=1, ncols=2)
+
+    for letter in ["X", "Y", "Z"]:
+        power = getattr(channel, f"{letter}power")
+        if power > 0:
+            gate = moose.element(f"{channel.path}/gate{letter}")
+            minf = gate.tableA / gate.tableB
+            mtau = 1 / gate.tableB
+            v = np.linspace(gate.min, gate.max, len(minf))
+            inf_f = f"{channel.name}.{letter}.inf.dat"
+            tau_f = f"{channel.name}.{letter}.tau.dat"
+            np.savetxt(
+                inf_f, np.block([v[:, np.newaxis], minf[:, np.newaxis]])
+            )
+            np.savetxt(
+                tau_f, np.block([v[:, np.newaxis], mtau[:, np.newaxis]])
+            )
+            logging.info(
+                f"Saved {letter} gate tables for {channel.name} in {inf_f} and {tau_f}"
+            )
+            if do_plot:
+                axes[0].plot(v, minf, label=f"inf {letter}")
+                axes[1].plot(v, mtau, label=f"tau {letter}")
+    if do_plot:
+        axes[0].legend()
+        axes[1].legend()
+        fig.suptitle(channel.name)
+
+
+def test_granule98():
+    modeldir = os.path.join(os.path.dirname(__file__), 'GranuleCell')
+    do_plot = True
+    reader = NML2Reader(verbose=True)
+    filename = os.path.join(modeldir, "GranuleCell.net.nml")
+    reader.read(filename)
+    pop_id = reader.doc.networks[0].populations[0].id
+    soma = reader.getComp(pop_id, cellIndex=0, segId=0)
+    data = moose.Neutral("/data")
+    pg = reader.getInput("Gran_10pA")
+    pg.firstWidth = 500e-3
+    inj = moose.Table(f"{data.path}/pulse")
+    moose.connect(inj, "requestOut", pg, "getOutputValue")
+    vm = moose.Table(f"{data.path}/Vm")
+    moose.connect(vm, "requestOut", soma, "getVm")
+    catab = None
+    for el in moose.wildcardFind("/model/##[TYPE=CaConc]"):
+        capool = moose.element(f"{soma.path}/{el.name}")
+        catab = moose.Table(f"{data.path}/{capool.name}")
+        moose.connect(catab, "requestOut", capool, "getCa")
+        print("Recording", capool.path, ".Ca in", catab.path)
+
+    chanmap = {}
+    gktabs = []
+    for el in moose.wildcardFind(
+        f"{soma.path}/##[TYPE=HHChannel]"
+    ) + moose.wildcardFind(f"{soma.path}/##[TYPE=HHChannel2D]"):
+        chan = moose.element(el)
+        chanmap[chan.name.split('_')[1]] = chan  # for debugging
+        tab = moose.Table(f"{data.path}/{chan.name}")
+        moose.connect(tab, "requestOut", chan, "getGk")
+        gktabs.append(tab)
+        print("Recording", chan.path, ".Gk in", tab.path)
+
+    if catab is not None:
+        gktabs.append(catab)
+
+    for ch in soma.children:
+        if moose.isinstance_(ch, moose.HHChannel):
+            dump_gate_tables(ch, do_plot=do_plot)
+
+    kca = chanmap['KCa']
+    gate = moose.element(f'{kca.path}/gateX')
+    vtab = np.linspace(gate.xmin, gate.xmax, gate.xdivs)
+    ctab = np.linspace(gate.ymin, gate.ymax, gate.ydivs)
+    cplot = [gate.A[-0.65, cc] for cc in ctab]
+    vplot = [gate.A[vv, 7.55e-5] for vv in vtab]
+    # fig, axes = plt.subplots(nrows=2)
+    # axes[0].plot(ctab, cplot, 'x')
+    # axes[0].set_xlabel('[Ca2+]')
+    # axes[0].set_ylabel('A')
+    # axes[1].plot(vtab, vplot, 'x')
+    # axes[1].set_xlabel('V')
+    # axes[1].set_ylabel('A')
+    # plt.show()
+    simtime = 700e-3
+    moose.reinit()
+    # breakpoint()
+    moose.start(simtime)
+
+    t = np.arange(len(vm.vector)) * vm.dt
+    print("%" * 10, len(vm.vector), len(inj.vector))
+    results = np.block(
+        [t[:, np.newaxis], vm.vector[:, np.newaxis], inj.vector[:, np.newaxis]]
+    )
+    fname = "Granule_98.dat"
+    np.savetxt(fname, X=results, header="time Vm Im", delimiter=" ")
+    print(f"Saved time, Vm, Im, in {fname}")
+    for tab in gktabs:
+        fname = f"{tab.name}.dat"
+        print(f"Saving {tab.name} in {fname}. {tab.vector[:10]}")
+        data = np.block([t[:, np.newaxis], tab.vector[:, np.newaxis]])
+        np.savetxt(fname, X=data, header="time Gk", delimiter=" ")
+    if do_plot:
+        fig, axes = plt.subplots(nrows=2, sharex="all")
+        axes[0].plot(t, vm.vector, label="Vm")
+        axes[1].plot(t, inj.vector, label="Im")
+        axes[0].legend()
+        axes[1].legend()
+        if catab is not None:
+            fig, ax = plt.subplots()
+            fig.suptitle("CaConc")
+            ax.plot(t, catab.vector)
+        plt.show()
+
+
+if __name__ == '__main__':
+    test_granule98()
+
+#
+# test_granule98.py ends here


### PR DESCRIPTION
- Loading HH ion channels was broken in NeuroML2 reader. Fixed.
- Added test script for NeuroML2 reader along with GranuleCell98 model files for testing
- Most tests were being skipped by pytest because of two early failures. The fixes were (1) moving random seed setting in Graupner Brunel STDP script from the top level to the test function, and (2) replacing deprecated `path` field by `reacSystemPath` in `Stoich`  elements.

- Fixed `children` field of `Neutral` broken in last update.