### PR TITLE
Fixed bug in hsolve trying to access empty vector element

### DIFF
--- a/hsolve/HSolveActive.cpp
+++ b/hsolve/HSolveActive.cpp
@@ -236,7 +236,8 @@ void HSolveActive::advanceChannels( double dt )
 
     for ( iv = V_.begin(); iv != V_.end(); ++iv )
     {
-        vTable_.row( *iv, vRow );
+	if (!vTable_.empty())
+	    vTable_.row( *iv, vRow );
         icarowcompt = caRowCompt_.begin();
         caBoundary = ica + *icacount;
         for ( ; ica < caBoundary; ++ica )

--- a/hsolve/HSolveActiveSetup.cpp
+++ b/hsolve/HSolveActiveSetup.cpp
@@ -96,7 +96,8 @@ void HSolveActive::reinitChannels()
     for ( iv = V_.begin(); iv != V_.end(); ++iv )
     {
 
-        vTable_.row( *iv, vRow );
+	if (!vTable_.empty())
+	    vTable_.row( *iv, vRow );
         icarowcompt = caRowCompt_.begin();
 
         caBoundary = ica + *icacount;
@@ -338,20 +339,15 @@ void HSolveActive::readCalcium()
 
 void HSolveActive::createLookupTables()
 {
-    std::set< Id > caSet;
-    std::set< Id > vSet;
     vector< Id > caGate;
     vector< Id > vGate;
     map< Id, unsigned int > gateSpecies;
 
     for ( unsigned int ig = 0; ig < gateId_.size(); ++ig )
         if ( gCaDepend_[ ig ] )
-            caSet.insert( gateId_[ ig ] );
+            caGate.push_back( gateId_[ ig ] );
         else
-            vSet.insert( gateId_[ ig ] );
-
-    caGate.insert( caGate.end(), caSet.begin(), caSet.end() );
-    vGate.insert( vGate.end(), vSet.begin(), vSet.end() );
+            vGate.push_back( gateId_[ ig ] );
 
     for ( unsigned int ig = 0; ig < caGate.size(); ++ig )
         gateSpecies[ caGate[ ig ] ] = ig;

--- a/hsolve/RateLookup.h
+++ b/hsolve/RateLookup.h
@@ -62,6 +62,9 @@ public:
 		double& C1,
 		double& C2 );
 
+    bool empty() const {
+	return table_.empty();
+    }
 private:
 	//~ vector< bool >       interpolate_;
 	vector< double >     table_;		///< Flattened table


### PR DESCRIPTION
- RateLookup in Hsolve was trying to access a vector entry even when it was uninitialized (no HHChannel).
- To fix, added a method RateLookup::empty() to tell if the inner vector is empty.
- Also, slight simplification of the code setting up RateLookup for gates.