### PR TITLE
Updated fix for MSVC warning while undoing the error for Linux

### DIFF
--- a/external/fmt/include/fmt/format.h
+++ b/external/fmt/include/fmt/format.h
@@ -87,6 +87,10 @@
 #else
 #  define FMT_FALLTHROUGH
 #endif
+// This is to avoid deprecation warning from MSVC
+#if defined(_MSC_VER)
+#define _SILENCE_STDEXT_ARR_ITERS_DEPRECATION_WARNING
+#endif
 
 #ifndef FMT_THROW
 #  if FMT_EXCEPTIONS

--- a/external/fmt/meson.build
+++ b/external/fmt/meson.build
@@ -8,6 +8,4 @@ fmt_src = [
 
 incdir = include_directories('include')
 
-# This is to avoid deprecation warning from MSVC:
-#   cpp_args: ['/D_SILENCE_ALL_MS_EXT_DEPRECATION_WARNINGS']
-fmt_lib = static_library('fmt', fmt_src, include_directories: incdir, cpp_args: ['/D_SILENCE_ALL_MS_EXT_DEPRECATION_WARNINGS'])
+fmt_lib = static_library('fmt', fmt_src, include_directories: incdir)

--- a/external/fmt/src/format.cc
+++ b/external/fmt/src/format.cc
@@ -5,6 +5,11 @@
 //
 // For the license information refer to format.h.
 
+// This is to avoid deprecation warning from MSVC
+#if defined(_MSC_VER)
+#define _SILENCE_STDEXT_ARR_ITERS_DEPRECATION_WARNING
+#endif
+
 #include "fmt/format-inl.h"
 
 FMT_BEGIN_NAMESPACE

--- a/external/fmt/src/os.cc
+++ b/external/fmt/src/os.cc
@@ -10,6 +10,12 @@
 #  define _CRT_SECURE_NO_WARNINGS
 #endif
 
+// This is to avoid deprecation warning from MSVC
+#if defined(_MSC_VER)
+#define _SILENCE_STDEXT_ARR_ITERS_DEPRECATION_WARNING
+#endif
+
+
 #include "fmt/os.h"
 
 #include <climits>


### PR DESCRIPTION
- Last fix for MSVC warnings introduced error for Linux - solved now.