### PR TITLE
v4.1.1 – Incremental Release over v4.1.0 "Jhangri"

### DIFF
--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -105,9 +105,24 @@ jobs:
           python -m cibuildwheel --output-dir wheelhouse
           dir wheelhouse
       - name: Upload packages
-        if: github.ref == 'refs/heads/main'
+        if: github.ref == 'refs/heads/development'
         uses: xresloader/upload-to-github-release@v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           file: "wheelhouse/pymoose*.whl"
+#      - name: Set up Python (for Twine)
+#        uses: actions/setup-python@v5
+#        with:
+#         python-version: '3.11'
+#      - name: Upload to PyPI
+#        if: always()
+#        env:
+#          TWINE_USERNAME: __token__  # Use __token__ as the username
+#          TWINE_PASSWORD: ${{ secrets.PYPI_API_TOKEN }}  # Use the secret with your PyPI token as the password
+#        run: |
+#          python -m pip install --upgrade twine  # Ensure Twine is installed again
+#          python -m twine --version  # Debug: Check Twine version
+#          which python  # Debug: Ensure Python is available
+#         which twine  # Debug: Check if Twine is correctly installed
+#          python -m twine upload wheelhouse/*.whl  # Upload the built wheels to PyPI

--- a/.github/workflows/pymoose.yml
+++ b/.github/workflows/pymoose.yml
@@ -1,3 +1,4 @@
+
 name: Build install test
 
 on: [push]
@@ -8,17 +9,26 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-22.04, macos-14, windows-latest]
+        os: [ubuntu-22.04, macos-14, macos-15, windows-latest]
         build_type: [Release]
         c_compiler: [clang]
         python-version: ["3.12"]
         include:
           - os: ubuntu-22.04
-            apt: 10
+            apt: 10  # Linux will install the latest GSL version
           - os: macos-14
-            brew: 20
+            brew: 20  # macOS will install the latest GSL version
+          - os: macos-15
+            brew: 20  
           - os: windows-latest
             winget: 30
+            gsl_version: "2.6"
+          - os: windows-latest
+            winget: 30
+            gsl_version: "2.7"
+          - os: windows-latest
+            winget: 30
+            gsl_version: "2.8"
     steps:
       - name: mamba-setup
         uses: mamba-org/setup-micromamba@v1
@@ -56,7 +66,8 @@ jobs:
           sudo apt-get -y install libgsl0-dev libgsl-dev libhdf5-dev
       - if: ${{ matrix.brew }}
         run: |
-          brew install gsl
+          brew list pkg-config && brew uninstall pkg-config || echo "pkg-config not installed, skipping uninstall."
+          brew install gsl  # Always install the latest GSL version on macOS
           brew install hdf5
       - name: checkout
         uses: actions/checkout@v4          

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,21 @@
 ## Unreleased
 *Unreleased changes go here*
 
+## [4.1.1] - 2025-06-23
+Jhangri
+
+### Added 
+- Added `HHChannelF` and `HHGateF` for formula-based evaluation of Hodgkin-Huxley type gating parameters
+- Added a formula interface for `HHGate`: Users can now assign string formula in `exprtk` syntax to `alphaExpr`, `betaExpr`, `tauExpr` and `infExpr` to fill up the               tables. These can take either `v` for voltage or `c` for concentration as independent variable names in the formula.
+- Added `moose.sysfields` to display system fields like `fieldIndex`, `numData` etc.
+
+### FIXED
+1. `bool` attribute handling added to `moose.vec`
+2. More informative error message for unhandled attributes in `moose.vec`
+3. Fixed issue #505
+4. `moose.setCwe()` now handles str, element (ObjId) and vec (Id) parameters correctly
+5. fixed `moose.showmsg()` mixing up incoming and outgoing messages.
+
 ## [4.1.0] - 2024-11-28
 Jhangri
 ### Added

--- a/README.md
+++ b/README.md
@@ -42,15 +42,6 @@ https://github.com/MooseNeuro/moose-examples.
 - A set of jupyter notebooks with step by step examples with explanation are available here:
 https://github.com/MooseNeuro/moose-notebooks.
 
-# Build 
-
-To build `pymoose`, follow instructions given in
-[INSTALL.md](INSTALL.md) and for platform specific
-information see:
-- Linux: [UbuntuBuild.md](UbuntuBuild.md)
-- MacOSX: [AppleM1Build.md](AppleM1Build.md)
-- Windows: [WindowsBuild.md](WindowsBuild.md)
-
 # ABOUT VERSION 4.1.1, `Jhangri`
 
 [`Jhangri`](https://en.wikipedia.org/wiki/Imarti) is an Indian sweet

--- a/README.md
+++ b/README.md
@@ -74,7 +74,13 @@ This release has the following changes:
 8. Attempt to access paths with non-existent element now consistently raises RuntimeError.
 9. `moose.delete` now accepts vec (Id) as argument.
 
+# Installation
+Installing released version from PyPI using `pip`
 
+This version is now available for installation via `pip`. To install the latest release, run
+```
+pip install pymoose
+```
 
 # Documentation
 1. Updated `Ubuntu` build instructions for better clarity.

--- a/README.md
+++ b/README.md
@@ -43,6 +43,9 @@ https://github.com/MooseNeuro/moose-examples.
 - A set of jupyter notebooks with step by step examples with explanation are available here:
 https://github.com/MooseNeuro/moose-notebooks.
 
+# v4.1.1 – Incremental Release over v4.1.0 "Jhangri"
+This version builds upon the v4.1.0 (Jhangri) release and includes important internal improvements, documentation enhancements, and binding support.
+
 # ABOUT VERSION 4.1.1, `Jhangri`
 
 [`Jhangri`](https://en.wikipedia.org/wiki/Imarti) is an Indian sweet
@@ -52,6 +55,33 @@ body, which is then soaked in sugar syrup lightly flavoured with
 spices.
 
 This release has the following changes:
+
+# Installation
+Installing released version from PyPI using `pip`
+
+This version is now available for installation via `pip`. To install the latest release, run
+```
+pip install pymoose
+```
+## Post installation
+
+You can check that moose is installed and initializes correctly by running:
+```
+$ python -c "import moose; ch = moose.HHChannel('ch'); moose.le()"
+```
+This should show 
+```
+Elements under /
+    /Msgs
+    /clock
+    /classes
+    /postmaster
+    /ch	
+```
+
+Now you can import moose in a Python script or interpreter with the statement:
+
+    >>> import moose
 
 # New Features
 1.  Formula-based versions of HH-type channels 
@@ -63,9 +93,9 @@ This release has the following changes:
 # API Updates
 1. API changes in  `moose.vec` and `moose.element,` including updated documentation.
 2. `moose.showfields` updated to 
- - skip system fields like `fieldIndex`, `numData` etc. These can now be printed using `sysfields` function.
- -  print common but informative fields like `name`, className`, `tick` and `dt` at the top.
- - return `None` instead of the output string to avoid cluttering the interactive session.
+   - skip system fields like `fieldIndex`, `numData` etc. These can now be printed using `sysfields` function.
+   -  print common but informative fields like `name`, `className`, `tick` and `dt` at the top.
+   - return `None` instead of the output string to avoid cluttering the interactive session.
 3. `moose.pwe()` returns `None` to avoid output clutter. Use `moose.getCwe()` for retrieving the current working element.
 4. `children` field of moose elements (ObjId) now return a list of elements instead of vecs (Id). This brings consistency between `parent` and `children` fields.
 5. `moose.le()` returns `None` to avoid output clutter. Use `element.children` field to access the list of children.
@@ -74,19 +104,6 @@ This release has the following changes:
 8. Attempt to access paths with non-existent element now consistently raises RuntimeError.
 9. `moose.delete` now accepts vec (Id) as argument.
 
-# Installation
-Installing released version from PyPI using `pip`
-
-This version is now available for installation via `pip`. To install the latest release, run
-```
-pip install pymoose
-```
-
-# Documentation
-1. Updated `Ubuntu` build instructions for better clarity.
-2. Enhanced documentation for `HHGate`, including additional warnings.
-3. Updated documentation for `Stoich,` with improved code comments and clarifications.
-
 # Bug Fixes
 1. `bool` attribute handling added to `moose.vec`
 2. More informative error message for unhandled attributes in `moose.vec`
@@ -94,7 +111,10 @@ pip install pymoose
 4. `moose.setCwe()` now handles str, element (ObjId) and vec (Id) parameters correctly
 5. fixed `moose.showmsg()` mixing up incoming and outgoing messages.
 
-
+# Documentation
+1. Updated `Ubuntu` build instructions for better clarity.
+2. Enhanced documentation for `HHGate`, including additional warnings.
+3. Updated documentation for `Stoich,` with improved code comments and clarifications.
    
 # LICENSE
 

--- a/README.md
+++ b/README.md
@@ -30,7 +30,8 @@ contains C++ codebase and python interface called `pymoose`. For more
 details about MOOSE simulator, visit https://moose.ncbs.res.in .
 
 
-----------
+-------------
+  
 # Installation
 
 See [docs/source/install/INSTALL.md](docs/source/install/INSTALL.md) for instructions on installation.

--- a/README.md
+++ b/README.md
@@ -33,10 +33,14 @@ details about MOOSE simulator, visit https://moose.ncbs.res.in .
 ----------
 # Installation
 
-See [INSTALL.md](INSTALL.md) for instructions on installation.
+See [docs/source/install/INSTALL.md](docs/source/install/INSTALL.md) for instructions on installation.
 
-Have a look at examples, tutorials and demo here
-https://github.com/BhallaLab/moose-examples.
+# Examples and Tutorials
+- Have a look at examples, tutorials and demo scripts here
+https://github.com/MooseNeuro/moose-examples.
+
+- A set of jupyter notebooks with step by step examples with explanation are available here:
+https://github.com/MooseNeuro/moose-notebooks.
 
 # Build 
 

--- a/README.md
+++ b/README.md
@@ -25,24 +25,29 @@ support for many model formats. These include SBML, NeuroML, GENESIS kkit
 and cell.p formats, HDF5 and NSDF for data writing.
 
 This is the core computational engine of [MOOSE
-simulator](https://mooseneuro.github.io). This repository
+simulator](https://github.com/BhallaLab/moose). This repository
 contains C++ codebase and python interface called `pymoose`. For more
-details about MOOSE simulator and old documentation, visit https://moose.ncbs.res.in .
+details about MOOSE simulator, visit https://moose.ncbs.res.in .
 
 
 ----------
 # Installation
 
-See [docs/source/install/INSTALL.md](docs/source/install/INSTALL.md) for instructions on installation.
+See [INSTALL.md](INSTALL.md) for instructions on installation.
 
-# Examples and Tutorials
-- Have a look at examples, tutorials and demo scripts here
-https://github.com/MooseNeuro/moose-examples.
+Have a look at examples, tutorials and demo here
+https://github.com/BhallaLab/moose-examples.
 
-- A set of jupyter notebooks with step by step examples with explanation are available here:
-https://github.com/MooseNeuro/moose-notebooks.
+# Build 
 
-# ABOUT VERSION 4.1.0, `Jhangri`
+To build `pymoose`, follow instructions given in
+[INSTALL.md](INSTALL.md) and for platform specific
+information see:
+- Linux: [UbuntuBuild.md](UbuntuBuild.md)
+- MacOSX: [AppleM1Build.md](AppleM1Build.md)
+- Windows: [WindowsBuild.md](WindowsBuild.md)
+
+# ABOUT VERSION 4.1.1, `Jhangri`
 
 [`Jhangri`](https://en.wikipedia.org/wiki/Imarti) is an Indian sweet
 in the shape of a flower. It is made of white-lentil (*Vigna mungo*)
@@ -50,19 +55,45 @@ batter, deep-fried in ornamental shape to form the crunchy, golden
 body, which is then soaked in sugar syrup lightly flavoured with
 spices.
 
-This release has the following major changes:
+This release has the following changes:
 
-1. Improved support for reading NeuroML2 models
-2. `HHGate2D`: separate `xminA`, `xminB`, etc. for `A` and `B` tables
-   replaced by single `xmin`, `xmax`, `xdivs`, `ymin`, `ymax`, and
-   `ydivs` fields for both tables.
-2. Build system switched from cmake to meson
-2. Native binaries for Windows
-6. Updated to conform to c/c++-17 standard
-7. Various bugfixes
+# New Features
+1.  Formula-based versions of HH-type channels 
+     - Added `HHChannelF` and `HHGateF` for formula-based evaluation of Hodgkin-Huxley type gating parameters
+     - Added a formula interface for `HHGate`: Users can now assign string formula in `exprtk` syntax to `alphaExpr`, `betaExpr`, `tauExpr` and `infExpr` to fill up the               tables. These can take either `v` for voltage or `c` for concentration as independent variable names in the formula.
+2. Added `moose.sysfields` to display system fields like `fieldIndex`, `numData` etc. 
+3. Reintroduced `moose.neighbors()` function to retrieve neighbors on a particular field. This allows more flexibility than `element.neighbors[fieldName]` by allowing the user to specify the message type ("Single", "OneToOne", etc.) and direction (1 for incoming 0 for outgoing, otherwise both directions).
 
+# API Updates
+1. API changes in  `moose.vec` and `moose.element,` including updated documentation.
+2. `moose.showfields` updated to 
+ - skip system fields like `fieldIndex`, `numData` etc. These can now be printed using `sysfields` function.
+ -  print common but informative fields like `name`, className`, `tick` and `dt` at the top.
+ - return `None` instead of the output string to avoid cluttering the interactive session.
+3. `moose.pwe()` returns `None` to avoid output clutter. Use `moose.getCwe()` for retrieving the current working element.
+4. `children` field of moose elements (ObjId) now return a list of elements instead of vecs (Id). This brings consistency between `parent` and `children` fields.
+5. `moose.le()` returns `None` to avoid output clutter. Use `element.children` field to access the list of children.
+6. `path` field for elements (ObjId) now includes the index in brackets, as in the core C++. This avoids confusion with vec (Id) objects.
+7. `moose.copy()` now accepts either `str` path or `element` or `vec` for `src` and `dest` parameters.
+8. Attempt to access paths with non-existent element now consistently raises RuntimeError.
+9. `moose.delete` now accepts vec (Id) as argument.
+
+
+
+# Documentation
+1. Updated `Ubuntu` build instructions for better clarity.
+2. Enhanced documentation for `HHGate`, including additional warnings.
+3. Updated documentation for `Stoich,` with improved code comments and clarifications.
+
+# Bug Fixes
+1. `bool` attribute handling added to `moose.vec`
+2. More informative error message for unhandled attributes in `moose.vec`
+3. Fixed issue #505
+4. `moose.setCwe()` now handles str, element (ObjId) and vec (Id) parameters correctly
+5. fixed `moose.showmsg()` mixing up incoming and outgoing messages.
+
+
+   
 # LICENSE
 
 MOOSE is released under GPLv3.
-
-

--- a/meson.build
+++ b/meson.build
@@ -13,7 +13,7 @@
 project('pymoose', 'c', 'cpp',
         # The version is created dynamically based on git commit hash. For release, make this explicit string        
         # version: run_command('git', 'rev-parse',  '--short', 'HEAD', check:false).stdout().strip(),
-        version: '4.1.0dev',  # cibuildwheel/meson crashes with github hash as version
+        version: '4.1.1',  # cibuildwheel/meson crashes with github hash as version
 	default_options: ['c_std=c17', 'cpp_std=c++17', 'b_ndebug=if-release'])
 
 pybind_dep = dependency('pybind11')
@@ -38,7 +38,7 @@ else
   mpi_dep = []
 endif  
 
-add_global_arguments('-DMOOSE_VERSION="4.1.0"', language: ['c', 'cpp'])
+add_global_arguments('-DMOOSE_VERSION="4.1.1"', language: ['c', 'cpp'])
 add_global_arguments('-DUSE_GSL', language: ['c', 'cpp'])
 
 ##############################################################

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ requires = [
 [project]
 name = 'pymoose'
 # dynamic = ['version']
-version = '4.1.0'
+version = '4.1.1'
 description = 'Python scripting interface of MOOSE Simulator (https://moose.ncbs.res.in)'
 readme = 'README.md'
 classifiers = [
@@ -60,9 +60,9 @@ maintainers = [
 dependencies = ['numpy>=1.23', 'matplotlib', 'vpython', 'python-libsbml', 'pyneuroml']
 
 [project.urls]
-homepage = 'https://moose.ncbs.res.in'
+homepage = 'https://mooseneuro.github.io/'
 documentation = 'https://moose.ncbs.res.in/readthedocs/index.html'
-repository = 'https://github.com/BhallaLab/moose-core'
+repository = 'https://github.com/MooseNeuro/moose-core.git'
 
 [project.optional-dependencies]
 test = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,7 @@ classifiers = [
     'Development Status :: 5 - Production/Stable',
     'Intended Audience :: Science/Research',
     'Intended Audience :: Developers',
-    'License :: OSI Approved :: GPL 3',
+    'License :: OSI Approved :: GNU General Public License v3 (GPLv3)',
     'Programming Language :: C',
     'Programming Language :: C++',
     'Programming Language :: Python',

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -80,7 +80,7 @@ dist = ['--include-subprojects']
 build = '*-macosx_* *-manylinux_x86_64 *-win_amd64 *-win_arm64'
 skip = "*-win32"
 test-skip = ""
-free-threaded-support = false
+#free-threaded-support = false
 
 archs = ["auto"]
 build-frontend = "default"


### PR DESCRIPTION
# ABOUT VERSION 4.1.1, `Jhangri`

This version builds upon the v4.1.0 (Jhangri) release and includes important internal improvements, documentation enhancements, and binding support.

[`Jhangri`](https://en.wikipedia.org/wiki/Imarti) is an Indian sweet
in the shape of a flower. It is made of white-lentil (*Vigna mungo*)
batter, deep-fried in ornamental shape to form the crunchy, golden
body, which is then soaked in sugar syrup lightly flavoured with
spices.

This release has the following changes:

# Installation
Installing released version from PyPI using `pip`

This version is now available for installation via `pip`. To install the latest release, run
```
pip install pymoose
```
## Post installation

You can check that moose is installed and initializes correctly by running:
```
$ python -c "import moose; ch = moose.HHChannel('ch'); moose.le()"
```
This should show 
```
Elements under /
    /Msgs
    /clock
    /classes
    /postmaster
    /ch	
```

Now you can import moose in a Python script or interpreter with the statement:

    >>> import moose

# New Features
1.  Formula-based versions of HH-type channels 
     - Added `HHChannelF` and `HHGateF` for formula-based evaluation of Hodgkin-Huxley type gating parameters
     - Added a formula interface for `HHGate`: Users can now assign string formula in `exprtk` syntax to `alphaExpr`, `betaExpr`, `tauExpr` and `infExpr` to fill up the               tables. These can take either `v` for voltage or `c` for concentration as independent variable names in the formula.
2. Added `moose.sysfields` to display system fields like `fieldIndex`, `numData` etc. 
3. Reintroduced `moose.neighbors()` function to retrieve neighbors on a particular field. This allows more flexibility than `element.neighbors[fieldName]` by allowing the user to specify the message type ("Single", "OneToOne", etc.) and direction (1 for incoming 0 for outgoing, otherwise both directions).

# API Updates
1. API changes in  `moose.vec` and `moose.element,` including updated documentation.
2. `moose.showfields` updated to 
    - skip system fields like `fieldIndex`, `numData` etc. These can now be printed using `sysfields` function.
    -  print common but informative fields like `name`, `className`, `tick`, and `dt` at the top.
    - return `None` instead of the output string to avoid cluttering the interactive session.
3. `moose.pwe()` returns `None` to avoid output clutter. Use `moose.getCwe()` for retrieving the current working element.
4. `children` field of moose elements (ObjId) now return a list of elements instead of vecs (Id). This brings consistency between `parent` and `children` fields.
5. `moose.le()` returns `None` to avoid output clutter. Use `element.children` field to access the list of children.
6. `path` field for elements (ObjId) now includes the index in brackets, as in the core C++. This avoids confusion with vec (Id) objects.
7. `moose.copy()` now accepts either `str` path or `element` or `vec` for `src` and `dest` parameters.
8. Attempt to access paths with non-existent element now consistently raises RuntimeError.
9. `moose.delete` now accepts vec (Id) as argument.

# Bug Fixes
1. `bool` attribute handling added to `moose.vec`
2. More informative error message for unhandled attributes in `moose.vec`
3. Fixed issue #505
4. `moose.setCwe()` now handles str, element (ObjId) and vec (Id) parameters correctly
5. fixed `moose.showmsg()` mixing up incoming and outgoing messages.

# Documentation
1. Updated `Ubuntu` build instructions for better clarity.
2. Enhanced documentation for `HHGate`, including additional warnings.
3. Updated documentation for `Stoich,` with improved code comments and clarifications.


   
# LICENSE

MOOSE is released under GPLv3.