### PR TITLE
Additional data types added for LookupFinfo keys

### DIFF
--- a/builtins/Function.cpp
+++ b/builtins/Function.cpp
@@ -322,7 +322,7 @@ the form::
 NOTE: `t` represents time. You CAN NOT use to for any other purpose.
 
 The constants must be defined before setting the expression using 
-the lookup field `c`. Once set, 
+the lookup field `c`. Once set, their values cannot be changed.
 
 The interpretation of variable names in expression depends on 
 `allowUnknownVariables` flag::

--- a/pybind11/Finfo.cpp
+++ b/pybind11/Finfo.cpp
@@ -239,6 +239,21 @@ py::object getLookupValueFinfoItem(const ObjId &oid, const Finfo *f,
     if(srcType == "unsigned int")
         return getLookupValueFinfoItemInner<unsigned int>(
             oid, f, key.cast<unsigned int>(), tgtType);
+    if(srcType == "unsigned long")
+        return getLookupValueFinfoItemInner<unsigned long>(
+            oid, f, key.cast<unsigned long>(), tgtType);
+    if(srcType == "long")
+        return getLookupValueFinfoItemInner<long>(
+            oid, f, key.cast<long>(), tgtType);
+    if(srcType == "int")
+        return getLookupValueFinfoItemInner<int>(
+            oid, f, key.cast<int>(), tgtType);
+    if(srcType == "float")
+        return getLookupValueFinfoItemInner<float>(
+            oid, f, key.cast<float>(), tgtType);
+    if(srcType == "double")
+        return getLookupValueFinfoItemInner<double>(
+            oid, f, key.cast<double>(), tgtType);
     if(srcType == "ObjId")
         return getLookupValueFinfoItemInner<ObjId>(oid, f, key.cast<ObjId>(),
                                                    tgtType);

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -80,7 +80,8 @@ dist = ['--include-subprojects']
 build = '*-macosx_* *-manylinux_x86_64 *-win_amd64 *-win_arm64'
 skip = "*-win32"
 test-skip = ""
-free-threaded-support = false
+
+# free-threaded-support = false
 
 archs = ["auto"]
 build-frontend = "default"


### PR DESCRIPTION
- Added support for float, int, long keys in LookupFinfo Python interface.
- Small update in pyproject.toml to fix issue with Windows wheel build on newer versions of meson