### PR TITLE
Merge Dev changes into Master : Enable manual workflow trigger and fix release permissions

### DIFF
--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -1,6 +1,9 @@
 name: Python package
 
-on: [push]
+on:
+  workflow_dispatch:
+permissions:
+  contents: write
 
 jobs:
   build_wheel:


### PR DESCRIPTION
## Summary
Updates the `.github/workflows/package.yml` configuration to allow for manual execution and correct permission issues.

## Changes
- **Update Trigger:** Switched `on: [push]` to `workflow_dispatch`. This stops the workflow from running on every push and allows it to be triggered manually from the Actions tab.
- **Fix Permissions:** Added `permissions: contents: write`. This is required for the workflow to perform write operations (such as creating releases or pushing tags).
