### PR TITLE
Remove incorrect positive value check in setCompartmentParams()

### DIFF
--- a/biophysics/Neuron.cpp
+++ b/biophysics/Neuron.cpp
@@ -788,14 +788,11 @@ static void setCompartmentParams(
         for ( unsigned int i = 0; i < elist.size(); ++i )
         {
             unsigned int j = i * nuParser::numVal;
-            if ( val[ j + nuParser::EXPR ] > 0 )
-            {
                 double len = val[j + nuParser::LEN ];
                 double dia = val[j + nuParser::DIA ];
                 double x = parser.eval( val.begin() + j );
                 assignSingleCompartmentParams( elist[i],
                                                x, field, len, dia );
-            }
         }
     }
     catch ( moose::Parser::exception_type& err )


### PR DESCRIPTION
## Summary
Found a bug in MOOSE's setCompartmentParams() function that prevents passive properties from being set when Em (negative value) is listed first. The function checks if the first expression is positive and applies that same check to all properties. This means even positive values like CM and RM get skipped.

To fix this, removed the incorrect top-level if (val[j + nuParser::EXPR] > 0) check. Property-specific validation already exists in assignSingleCompartmentParams().

## Files Changed
- `moose-core/biophysics/Neuron.cpp`

## Detailed bug report
https://github.com/orgs/MooseNeuro/discussions/44