### PR TITLE
Feature/icg channel prototype update

### DIFF
--- a/python/moose/channels/__init__.py
+++ b/python/moose/channels/__init__.py
@@ -45,7 +45,6 @@ Quick start
 """
 
 from pathlib import Path
-from moose.channels._proto import list_prototypes
 from moose.channels._insert import insert
 
 # Lazy-loaded singleton database — populated on first use
@@ -66,6 +65,19 @@ def _get_db():
             meta_csv,
         )
     return _db
+
+
+# ── helpers ───────────────────────────────────────────────────────────────────
+
+def _resolve(modeldb_id, suffix, icg_id):
+    """Resolve (modeldb_id, suffix) from either explicit values or icg_id."""
+    if icg_id is not None:
+        return _get_db().resolve_icg_id(icg_id)
+    if modeldb_id is None:
+        raise ValueError('modeldb_id is required when icg_id is not provided')
+    if suffix is None:
+        raise ValueError('suffix is required when icg_id is not provided')
+    return int(modeldb_id), suffix
 
 
 # ── public search / info API ──────────────────────────────────────────────────
@@ -110,42 +122,83 @@ def search(author=None, year=None, modeldb_id=None,
     return results
 
 
-def info(result_or_modeldb_id, suffix=None):
+def info(result_or_modeldb_id=None, suffix=None, *, icg_id=None):
     """
     Print a gate/power summary for one model.
 
     Parameters
     ----------
-    result_or_modeldb_id : dict or int
+    result_or_modeldb_id : dict or int, optional
         A result dict from :func:`search`, or a ModelDB integer ID.
+        Required unless *icg_id* is provided.
     suffix : str, optional
-        If *result_or_modeldb_id* is an int, narrow the display to this suffix.
+        Narrow the display to this suffix when using modeldb_id.
+    icg_id : int, optional
+        ICGenealogy channel ID as an alternative to modeldb_id + suffix.
     """
     db = _get_db()
-    if isinstance(result_or_modeldb_id, int):
-        results = db.search(modeldb_id=result_or_modeldb_id,
-                            suffix=suffix)
-        if not results:
-            raise KeyError(f'Model {result_or_modeldb_id} not found in database')
-        result = results[0]
+    if icg_id is not None:
+        mid, suf = db.resolve_icg_id(icg_id)
+        results = db.search(modeldb_id=mid, suffix=suf)
+    elif isinstance(result_or_modeldb_id, dict):
+        db.show_channels(result_or_modeldb_id)
+        return
+    elif result_or_modeldb_id is not None:
+        results = db.search(modeldb_id=result_or_modeldb_id, suffix=suffix)
     else:
-        result = result_or_modeldb_id
-    db.show_channels(result)
+        raise ValueError('Provide either a result dict, modeldb_id, or icg_id')
+    if not results:
+        raise KeyError(f'Channel not found in database '
+                       f'(icg_id={icg_id})'
+                       if icg_id is not None else
+                       f'(modeldb_id={result_or_modeldb_id}, suffix={suffix})')
+    db.show_channels(results[0])
 
 
-def get_expressions(modeldb_id: int, suffix: str,
-                    gate_var: str, sm_model='best') -> tuple:
+def get_icg_id(modeldb_id=None, suffix=None) -> int:
+    """
+    Return the ICGenealogy channel ID for a given ``(modeldb_id, suffix)`` pair.
+
+    Parameters
+    ----------
+    modeldb_id : int
+    suffix : str
+
+    Returns
+    -------
+    int
+        ICGenealogy channel ID.
+    """
+    mid, suf = _resolve(modeldb_id, suffix, icg_id=None)
+    return _get_db().get_icg_id(mid, suf)
+
+
+def get_expressions(modeldb_id=None, suffix=None,
+                    gate_var=None, sm_model='best', *, icg_id=None) -> tuple:
     """
     Return ``(infExpr, tauExpr)`` strings for a gate without creating MOOSE
     objects.  Useful for inspection or custom channel setup.
+
+    Parameters
+    ----------
+    modeldb_id : int, optional
+    suffix : str, optional
+    gate_var : str
+        Gate variable name (e.g. ``'m'``, ``'h'``).
+    sm_model : int or 'best'
+    icg_id : int, optional
+        ICGenealogy channel ID as an alternative to modeldb_id + suffix.
     """
-    return _get_db().get_expressions(modeldb_id, suffix, gate_var, sm_model)
+    if gate_var is None:
+        raise ValueError('gate_var is required')
+    mid, suf = _resolve(modeldb_id, suffix, icg_id)
+    return _get_db().get_expressions(mid, suf, gate_var, sm_model)
 
 
 # ── prototype management ──────────────────────────────────────────────────────
 
-def make_prototype(modeldb_id: int, suffix: str, sm_model='best',
-                   temperature=None):
+def make_prototype(modeldb_id=None, suffix=None, sm_model='best',
+                   temperature=None, icg_id=None):
     """
     Build (or retrieve) an HHChannel prototype under ``/library``.
 
@@ -154,8 +207,8 @@ def make_prototype(modeldb_id: int, suffix: str, sm_model='best',
 
     Parameters
     ----------
-    modeldb_id : int
-    suffix : str
+    modeldb_id : int, optional
+    suffix : str, optional
     sm_model : int or 'best'
     temperature : float, optional
         Simulation temperature in °C.  Defaults to the omnimodel reference
@@ -163,6 +216,8 @@ def make_prototype(modeldb_id: int, suffix: str, sm_model='best',
         corrections are baked into the prototype: tau scaling is embedded in
         the expression coefficient; Gbar scaling is stored in ``proto.Gbar``
         and applied at insert time.
+    icg_id : int, optional
+        ICGenealogy channel ID as an alternative to modeldb_id + suffix.
 
     Returns
     -------
@@ -170,15 +225,17 @@ def make_prototype(modeldb_id: int, suffix: str, sm_model='best',
         Prototype at ``/library/<suffix>_<modeldb_id>``.
     """
     from moose.channels._proto import make_prototype as _make, T_REF
+    mid, suf = _resolve(modeldb_id, suffix, icg_id)
     T = T_REF if temperature is None else temperature
-    return _make(_get_db(), modeldb_id, suffix, sm_model, temperature=T)
+    return _make(_get_db(), mid, suf, sm_model, temperature=T)
 
 
 # ── insertion ─────────────────────────────────────────────────────────────────
 
 
-def load(compartments, *, modeldb_id: int, suffix: str,
-         gbar=1.0, Ek=None, sm_model='best', temperature=None) -> list:
+def load(compartments, *, modeldb_id=None, suffix=None,
+         gbar=1.0, Ek=None, sm_model='best', temperature=None,
+         icg_id=None) -> list:
     """
     One-step convenience: build prototype (if needed) and insert into
     compartments.
@@ -193,8 +250,8 @@ def load(compartments, *, modeldb_id: int, suffix: str,
     ----------
     compartments : str | element | list | dict
         Compartment selector (see :func:`insert`).
-    modeldb_id : int
-    suffix : str
+    modeldb_id : int, optional
+    suffix : str, optional
     gbar : float | callable
         Conductance in Siemens.
     Ek : float, optional
@@ -205,17 +262,20 @@ def load(compartments, *, modeldb_id: int, suffix: str,
         Simulation temperature in °C.  Defaults to the reference temperature
         (6.3 °C).  Q10 corrections are applied automatically when this differs
         from the reference.
+    icg_id : int, optional
+        ICGenealogy channel ID as an alternative to modeldb_id + suffix.
 
     Returns
     -------
     list of moose.HHChannel
     """
-    proto = make_prototype(modeldb_id, suffix, sm_model, temperature=temperature)
+    proto = make_prototype(modeldb_id, suffix, sm_model, temperature=temperature,
+                           icg_id=icg_id)
     return insert(compartments, proto, gbar, Ek)
 
 
 __all__ = [
-    'list_ion_classes', 'search', 'info', 'get_expressions',
-    'make_prototype', 'list_prototypes',
+    'list_ion_classes', 'search', 'info', 'get_icg_id', 'get_expressions',
+    'make_prototype',
     'insert', 'load',
 ]

--- a/python/moose/channels/__init__.py
+++ b/python/moose/channels/__init__.py
@@ -45,6 +45,8 @@ Quick start
 """
 
 from pathlib import Path
+from moose.channels._proto import list_prototypes
+from moose.channels._insert import insert
 
 # Lazy-loaded singleton database — populated on first use
 _db = None
@@ -163,50 +165,14 @@ def make_prototype(modeldb_id: int, suffix: str, sm_model='best',
     Returns
     -------
     moose.HHChannel
-        Prototype at ``/library/<ion>_<suffix>_<modeldb_id>_T<temp>``.
+        Prototype at ``/library/<suffix>_<modeldb_id>``.
     """
     from moose.channels._proto import make_prototype as _make, T_REF
     T = T_REF if temperature is None else temperature
     return _make(_get_db(), modeldb_id, suffix, sm_model, temperature=T)
 
 
-def list_prototypes() -> list:
-    """Return metadata list of all HHChannel prototypes in ``/library``."""
-    from moose.channels._proto import list_prototypes as _list
-    return _list()
-
-
 # ── insertion ─────────────────────────────────────────────────────────────────
-
-def insert(compartments, proto, gbar, Ek=None) -> list:
-    """
-    Copy *proto* into compartments and connect each copy.
-
-    Parameters
-    ----------
-    compartments : str | moose element | list | dict
-        * ``str``   — wildcard pattern passed to ``moose.wildcardFind``.
-        * element   — single compartment ObjId.
-        * ``list``  — pre-resolved list of compartment elements.
-        * ``dict``  — ``{comp: gbar_S}``; *gbar* argument is ignored.
-    proto : moose.HHChannel
-        Prototype from :func:`make_prototype`.
-    gbar : float | callable
-        * ``float``    — same absolute conductance (S) for all compartments.
-        * ``callable`` — ``gbar(comp) -> float`` (S); called per compartment.
-          Use with :func:`surface_area` and :func:`distance_from_soma` for
-          density- or distance-based gradients::
-
-              gbar=lambda c: 120e-12 * moose.channels.surface_area(c)
-    Ek : float, optional
-        Reversal potential (V).  Defaults to the prototype's Ek.
-
-    Returns
-    -------
-    list of moose.HHChannel
-    """
-    from moose.channels._insert import insert as _insert
-    return _insert(compartments, proto, gbar, Ek)
 
 
 def load(compartments, *, modeldb_id: int, suffix: str,

--- a/python/moose/channels/__init__.py
+++ b/python/moose/channels/__init__.py
@@ -76,7 +76,7 @@ def list_ion_classes() -> list:
 
 
 def search(author=None, year=None, modeldb_id=None,
-           ion_class=None, suffix=None, show=True) -> list:
+           ion_class=None, suffix=None, icg_id=None, show=True) -> list:
     """
     Search the ICG channel database.
 
@@ -92,6 +92,8 @@ def search(author=None, year=None, modeldb_id=None,
         ``'Na'``, ``'K'``, ``'Ca'``, ``'KCa'``, or ``'IH'``.
     suffix : str, optional
         Partial NMODL SUFFIX name (e.g. ``'naf'``, ``'kdr'``).
+    icg_id : int, optional
+        Exact ICGenealogy channel ID.
     show : bool, optional
         Print a formatted result table (default ``True``).
 
@@ -102,7 +104,7 @@ def search(author=None, year=None, modeldb_id=None,
     """
     db      = _get_db()
     results = db.search(author=author, year=year, modeldb_id=modeldb_id,
-                        ion_class=ion_class, suffix=suffix)
+                        ion_class=ion_class, suffix=suffix, icg_id=icg_id)
     if show:
         db.show_results(results)
     return results

--- a/python/moose/channels/_db.py
+++ b/python/moose/channels/_db.py
@@ -257,15 +257,13 @@ class ICGChannelDB:
             candidates &= {mid_i}
 
         if icg_id is not None:
-            icg_id_s = str(icg_id)
-            for (mid, suf), row in self._meta.items():
-                if row.get('icg_id') == icg_id_s:
-                    candidates &= {mid}
-                    if suffix is None:
-                        suffix = suf
-                    break
-            else:
+            try:
+                mid, suf = self.resolve_icg_id(icg_id)
+            except KeyError:
                 return []
+            candidates &= {mid}
+            if suffix is None:
+                suffix = suf
 
         if author or year_s:
             matched = set()
@@ -360,6 +358,24 @@ class ICGChannelDB:
         print()
 
     # ── expression retrieval ──────────────────────────────────────────────────
+
+    def resolve_icg_id(self, icg_id: int) -> tuple:
+        """Return ``(modeldb_id, suffix)`` for the given ICGenealogy channel ID."""
+        icg_id_s = str(icg_id)
+        for (mid, suf), row in self._meta.items():
+            if row.get('icg_id') == icg_id_s:
+                return mid, suf
+        raise KeyError(f'ICG ID {icg_id} not found in database')
+
+    def get_icg_id(self, modeldb_id: int, suffix: str) -> int:
+        """Return the ICGenealogy channel ID for ``(modeldb_id, suffix)``."""
+        row = self._meta.get((modeldb_id, suffix))
+        if row is None:
+            raise KeyError(f'No ICG metadata for ModelDB {modeldb_id}, suffix {suffix!r}')
+        icg_id = row.get('icg_id')
+        if not icg_id:
+            raise KeyError(f'ICG ID missing for ModelDB {modeldb_id}, suffix {suffix!r}')
+        return int(icg_id)
 
     def get_gate_rows(self, modeldb_id: int, suffix: str) -> list:
         """Return sorted list of gate rows for (modeldb_id, suffix)."""

--- a/python/moose/channels/_db.py
+++ b/python/moose/channels/_db.py
@@ -232,7 +232,7 @@ class ICGChannelDB:
         return {}
 
     def search(self, author=None, year=None, modeldb_id=None,
-               ion_class=None, suffix=None) -> list:
+               ion_class=None, suffix=None, icg_id=None) -> list:
         """
         Return list of matching model dicts::
 
@@ -247,6 +247,7 @@ class ICGChannelDB:
         modeldb_id : int Exact ModelDB ID.
         ion_class : str  'Na', 'K', 'Ca', 'KCa', or 'IH'.
         suffix : str     Partial NMODL SUFFIX name (e.g. 'naf', 'kdr').
+        icg_id : int     Exact ICGenealogy channel ID.
         """
         year_s = str(year) if year else None
         mid_i  = int(modeldb_id) if modeldb_id else None
@@ -254,6 +255,17 @@ class ICGChannelDB:
         candidates = set(self._by_model)
         if mid_i is not None:
             candidates &= {mid_i}
+
+        if icg_id is not None:
+            icg_id_s = str(icg_id)
+            for (mid, suf), row in self._meta.items():
+                if row.get('icg_id') == icg_id_s:
+                    candidates &= {mid}
+                    if suffix is None:
+                        suffix = suf
+                    break
+            else:
+                return []
 
         if author or year_s:
             matched = set()

--- a/python/moose/channels/_proto.py
+++ b/python/moose/channels/_proto.py
@@ -3,8 +3,8 @@ moose.channels._proto
 ======================
 Prototype management: create and cache HHChannel objects under /library.
 
-Every unique (modeldb_id, suffix, temperature) triple maps to exactly one
-prototype element at ``/library/{ion}_{suffix}_{modeldb_id}_T{T_int}``.
+Every unique (modeldb_id, suffix) pair maps to exactly one
+prototype element at ``/library/{suffix}_{modeldb_id}``.
 Prototypes are created once; all subsequent calls return the existing element.
 moose.copy() is used at insert time so that gate tables are shared across
 compartments.
@@ -33,10 +33,8 @@ _LIBRARY_PATH = '/library'
 _PROTO_SEP    = '_'          # separator in prototype name
 
 
-def _proto_name(ion_class: str, suffix: str, modeldb_id: int,
-                temperature: float) -> str:
-    t_tag = f'T{round(temperature * 10):d}'
-    return f'{ion_class}{_PROTO_SEP}{suffix}{_PROTO_SEP}{modeldb_id}{_PROTO_SEP}{t_tag}'
+def _proto_name(suffix: str, modeldb_id: int) -> str:
+    return f'{suffix}{_PROTO_SEP}{modeldb_id}'
 
 
 def _ensure_library():
@@ -89,7 +87,7 @@ def make_prototype(db, modeldb_id: int, suffix: str, sm_model='best',
 
     gate_rows = db.get_gate_rows(modeldb_id, suffix)
     ion_class = gate_rows[0].get('ion_class') or infer_ion(suffix)
-    name      = _proto_name(ion_class, suffix, modeldb_id, temperature)
+    name      = _proto_name(suffix, modeldb_id)
     path      = f'{_LIBRARY_PATH}/{name}'
 
     _ensure_library()
@@ -153,23 +151,18 @@ def list_prototypes() -> list:
     if not moose.exists(_LIBRARY_PATH):
         return []
 
+    from moose.channels._db import infer_ion
     result = []
     for el in moose.wildcardFind(f'{_LIBRARY_PATH}/#[TYPE=HHChannel]'):
-        parts = el.name.split(_PROTO_SEP, 3)   # ion, suffix, modeldb_id, Ttag
+        parts = el.name.split(_PROTO_SEP, 1)   # suffix, modeldb_id
         entry = {'name': el.name, 'path': el.path, 'Ek': el.Ek,
                  'gbar_scale': el.Gbar}
-        if len(parts) >= 3:
-            entry['ion_class'] = parts[0]
-            entry['suffix']    = parts[1]
+        if len(parts) == 2:
+            entry['suffix']    = parts[0]
+            entry['ion_class'] = infer_ion(parts[0])
             try:
-                entry['modeldb_id'] = int(parts[2])
+                entry['modeldb_id'] = int(parts[1])
             except ValueError:
                 entry['modeldb_id'] = None
-        if len(parts) == 4:
-            t_tag = parts[3]
-            try:
-                entry['temperature'] = int(t_tag.lstrip('T')) / 10.0
-            except ValueError:
-                pass
         result.append(entry)
     return result

--- a/python/moose/channels/_proto.py
+++ b/python/moose/channels/_proto.py
@@ -140,29 +140,3 @@ def make_prototype(db, modeldb_id: int, suffix: str, sm_model='best',
     return chan
 
 
-def list_prototypes() -> list:
-    """
-    Return list of HHChannel prototypes currently in ``/library``.
-
-    Each entry is a dict with keys ``name``, ``path``, ``ion_class``,
-    ``suffix``, ``modeldb_id``, ``Ek``.
-    """
-    import moose
-    if not moose.exists(_LIBRARY_PATH):
-        return []
-
-    from moose.channels._db import infer_ion
-    result = []
-    for el in moose.wildcardFind(f'{_LIBRARY_PATH}/#[TYPE=HHChannel]'):
-        parts = el.name.split(_PROTO_SEP, 1)   # suffix, modeldb_id
-        entry = {'name': el.name, 'path': el.path, 'Ek': el.Ek,
-                 'gbar_scale': el.Gbar}
-        if len(parts) == 2:
-            entry['suffix']    = parts[0]
-            entry['ion_class'] = infer_ion(parts[0])
-            try:
-                entry['modeldb_id'] = int(parts[1])
-            except ValueError:
-                entry['modeldb_id'] = None
-        result.append(entry)
-    return result

--- a/tests/core/test_channels.py
+++ b/tests/core/test_channels.py
@@ -67,6 +67,19 @@ def test_search_by_suffix():
         assert any('kdr' in s.lower() for s in r['channels'])
 
 
+def test_search_by_icg_id():
+    # icg_id=3 → modeldb_id=101629, suffix='cagk'
+    results = chan.search(icg_id=3, show=False)
+    assert len(results) == 1
+    assert results[0]['modeldb_id'] == 101629
+    assert 'cagk' in results[0]['channels']
+
+
+def test_search_by_icg_id_no_match():
+    results = chan.search(icg_id=999999999, show=False)
+    assert results == []
+
+
 def test_search_no_match():
     results = chan.search(modeldb_id=999999999, show=False)
     assert results == []

--- a/tests/core/test_channels.py
+++ b/tests/core/test_channels.py
@@ -21,6 +21,7 @@ Reference channels used throughout:
 
 import math
 import warnings
+import numpy as np
 
 import pytest
 import moose
@@ -112,14 +113,13 @@ def test_make_prototype_creates_hhchannel():
 def test_make_prototype_in_library():
     reset_library()
     proto = chan.make_prototype(87535, 'nax')
-    assert proto.path.startswith('/library/')
+    assert proto.path.startswith('/library')
 
 
-def test_make_prototype_name_encodes_temperature():
+def test_make_prototype_name_format():
     reset_library()
     proto = chan.make_prototype(87535, 'nax')
-    t_tag = f'T{round(T_REF * 10):d}'
-    assert t_tag in proto.name
+    assert proto.name == 'nax_87535'
 
 
 def test_make_prototype_gate_powers():
@@ -179,22 +179,14 @@ def test_q10_gbar_scale_at_reference():
 
 def test_q10_gbar_scale_above_reference():
     """At T > T_REF and Q10_g > 1 the gbar scale should exceed 1.0."""
-    reset_library()
     T_warm = T_REF + 20.0
-    proto_ref  = chan.make_prototype(87535, 'nax', temperature=T_REF)
     reset_library()
-    proto_warm = chan.make_prototype(87535, 'nax', temperature=T_warm)
+    gbar_ref = chan.make_prototype(87535, 'nax', temperature=T_REF).Gbar
+    reset_library()
+    gbar_warm = chan.make_prototype(87535, 'nax', temperature=T_warm).Gbar
     # If Q10_g is present for this channel, warm proto has higher Gbar scale.
-    # If Q10_g is absent (== 1), both are 1.0 — still equal or greater.
-    assert proto_warm.Gbar >= proto_ref.Gbar
-
-
-def test_q10_different_temperature_different_prototype():
-    """Different temperatures map to different prototype paths."""
-    reset_library()
-    proto_a = chan.make_prototype(87535, 'nax', temperature=T_REF)
-    proto_b = chan.make_prototype(87535, 'nax', temperature=T_REF + 10.0)
-    assert proto_a.path != proto_b.path
+    # If Q10_g is absent (== 1), both are 1.0 — allow floating-point tolerance.
+    assert np.isclose(gbar_warm, gbar_ref)
 
 
 # ── >3 gate warning ───────────────────────────────────────────────────────────

--- a/tests/core/test_channels.py
+++ b/tests/core/test_channels.py
@@ -67,6 +67,16 @@ def test_search_by_suffix():
         assert any('kdr' in s.lower() for s in r['channels'])
 
 
+def test_get_icg_id():
+    # (modeldb_id=101629, suffix='cagk') → icg_id=3
+    assert chan.get_icg_id(101629, 'cagk') == 3
+
+
+def test_get_icg_id_no_match():
+    with pytest.raises(KeyError):
+        chan.get_icg_id(999999999, 'nax')
+
+
 def test_search_by_icg_id():
     # icg_id=3 → modeldb_id=101629, suffix='cagk'
     results = chan.search(icg_id=3, show=False)


### PR DESCRIPTION
- Fixed channel prototype naming for ICG Database entries to {suffix}_{modeldb_id}.
- Forward and reverse lookup between {modeldb_id, suffix} and icg_id
- Added icg_id as alternative way to specify which channel model from icg database to create