### PR TITLE
Fix moose.element() to cast result to the appropriate class

### DIFF
--- a/python/moose/__init__.py
+++ b/python/moose/__init__.py
@@ -87,6 +87,24 @@ for p in _moose.wildcardFind("/##[TYPE=Cinfo]"):
 from moose._moose import *
 
 
+# Override C++ builtin element() to convert to right class
+def element(obj):
+    """Convert path/object to a moose object of the appropriate
+    type. For Vec object it returns the first element
+
+    Parameters
+    ----------
+    obj: str, ObjId, Id, vec, instance of any moose class
+        The element to be converted
+
+    Returns
+    -------
+    A moose object of the appropriate class.
+    """
+    if isinstance(obj, _moose.vec):
+        obj = obj[0]
+    return __to_melement(_moose.element(obj))
+
 def version():
     """Returns moose version string."""
     return _moose.__version__


### PR DESCRIPTION
The nanobind-based _moose.element() returns a bare ObjId without casting the element to its specific MOOSE class, unlike the older implementation. Override element() in the Python layer to convert the result via __to_melement() (and return the first entry for a vec), so moose.element() again yields a properly typed object.