### PR TITLE
Accept Python ints for boolean fields

### DIFF
--- a/pymoose/MooseVec.cpp
+++ b/pymoose/MooseVec.cpp
@@ -196,8 +196,15 @@ bool MooseVec::setAttribute(const string& name, const nb::object& val)
         if(rttType == "int")
             return setAttrOneToOne<int>(
                 name, nb::cast<vector<int>>(val));
-        if(rttType == "bool")
-            return setAttrOneToOne<bool>(name, nb::cast<vector<bool>>(val));
+        if(rttType == "bool") {
+            // Convert each element via Python truthiness (like `bool(x)`) so a
+            // list of ints (0/1) works; nanobind's bool caster is strict and
+            // only accepts True/False.
+            vector<bool> bvec;
+            for(auto item : val)
+                bvec.push_back(nb::cast<bool>(nb::bool_(item)));
+            return setAttrOneToOne<bool>(name, bvec);
+        }
         if(rttType == "string")
             return setAttrOneToOne<string>(name, nb::cast<vector<string>>(val));
     }
@@ -211,7 +218,9 @@ bool MooseVec::setAttribute(const string& name, const nb::object& val)
             return setAttrOneToAll< int>(name,
                 nb::cast<int>(val));
         if(rttType == "bool")
-            return setAttrOneToAll<bool>(name, nb::cast<bool>(val));
+            // Use Python truthiness so ints (0/1) and other objects convert
+            // as expected; nanobind's bool caster only accepts True/False.
+            return setAttrOneToAll<bool>(name, nb::cast<bool>(nb::bool_(val)));
           if (rttType == "string")
               return setAttrOneToAll<string>(name, nb::cast<string>(val));
     }

--- a/pymoose/helper.cpp
+++ b/pymoose/helper.cpp
@@ -291,7 +291,10 @@ bool setFieldGeneric(const ObjId &oid, const string &fieldName,
     if(fieldType == "int")
         return Field<int>::set(oid, fieldName, nb::cast<int>(val));
     if(fieldType == "bool")
-        return Field<bool>::set(oid, fieldName, nb::cast<bool>(val));
+        // Use Python truthiness (like `bool(val)`) so that ints (0/1) and
+        // other objects convert as a Python user would expect. nanobind's
+        // bool caster is strict and only accepts actual True/False.
+        return Field<bool>::set(oid, fieldName, nb::cast<bool>(nb::bool_(val)));
     if(fieldType == "string")
         return Field<string>::set(oid, fieldName, nb::cast<string>(val));
     if(fieldType == "vector<string>")


### PR DESCRIPTION
The nanobind migration made boolean field assignment strict: nanobind's bool type caster only accepts actual True/False, so `obj.boolField = 1` (or 0) raised a cast error, unlike the previous pybind11 behaviour.

Route bool values through nb::bool_ (PyObject_IsTrue) so that ints and other objects convert using standard Python truthiness, in all three assignment paths:
- setFieldGeneric (scalar field, helper.cpp)
- MooseVec one-to-all broadcast (MooseVec.cpp)
- MooseVec one-to-one list assignment, per element (MooseVec.cpp)