### PR TITLE
Reinstated setField for backward compatibility.

### DIFF
--- a/pymoose/docs.h
+++ b/pymoose/docs.h
@@ -286,7 +286,7 @@ constexpr const char* getFieldGeneric = R"(Get field `field` of element `obj`.
 Parameters
 ----------
 obj: melement
-    object to retrieve field of.
+    object to retrieve field of
 field: str
     name of the field to be retrieved
 
@@ -295,6 +295,18 @@ Returns
 field value if `field` names a valueFinfo; if `field` names a
 destFinfo, the corresponding callable; a LookupField or ElementField
 object for those finfo types.
+)";
+
+constexpr const char* setFieldGeneric = R"(Set field `field` of element `obj` using value `value`.
+
+Parameters
+----------
+obj: melement
+    object to set field of
+field: str
+    name of the field to be set
+value: value type
+    value to assign to the field
 )";
 
 constexpr const char* setClock =

--- a/pymoose/pymoose.cpp
+++ b/pymoose/pymoose.cpp
@@ -399,6 +399,9 @@ Designed to simulate neural systems at multiple scales: From subcellular compone
     m.def("getField", &pymoose::getFieldGeneric, nb::arg("obj"),
           nb::arg("field"), docs::getFieldGeneric);
 
+    m.def("setField", &pymoose::setFieldGeneric, nb::arg("obj"),
+        nb::arg("field"), nb::arg("value"), docs::setFieldGeneric);
+
     m.def("setClock", &pymoose::setClock, nb::arg("tick"), nb::arg("dt"),
           docs::setClock);
     m.def("useClock", &pymoose::useClock, nb::arg("tick"), nb::arg("path"),


### PR DESCRIPTION
`moose.setField` and `moose.getField` are needed for backward compatibility.
New code should use Python's builtin `setattr` and `getattr`.